### PR TITLE
chore(client-mobile): hoist packages

### DIFF
--- a/packages/client-mobile/metro.config.js
+++ b/packages/client-mobile/metro.config.js
@@ -11,6 +11,7 @@ const config = {};
 
 function getConfig(appDir) {
   return {
+    projectRoot: path.resolve(appDir),
     watchFolders: [
       path.resolve(appDir, "../../node_modules"),
       path.resolve(appDir, "../../node_modules/@quoll/ui-primitives"),

--- a/packages/client-mobile/package.json
+++ b/packages/client-mobile/package.json
@@ -10,11 +10,6 @@
     "start": "react-native start",
     "test": "jest"
   },
-  "workspaces": {
-    "nohoist": [
-      "**"
-    ]
-  },
   "dependencies": {
     "@quoll/ui-primitives": "^0.3.0",
     "@react-navigation/bottom-tabs": "^6.5.11",


### PR DESCRIPTION
* Original build avoided hoisting in order to build successfully
* But specifying the `rootDirectory` and `watchFolders` could be done instead
https://metrobundler.dev/docs/configuration/#projectroot