### PR TITLE
chore: add version resolution for `@types/react`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "lerna": "^8.0.0",
     "lint-staged": "^15.2.0",
     "prettier": "^3.1.0"
+  },
+  "resolutions": {
+    "@types/react": "^18.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "prettier": "^3.1.0"
   },
   "resolutions": {
-    "@types/react": "^18.2.6"
+    "@types/react": "^18.2.45"
   }
 }

--- a/packages/client-mobile/package.json
+++ b/packages/client-mobile/package.json
@@ -27,7 +27,7 @@
     "@react-native/eslint-config": "^0.74.0",
     "@react-native/metro-config": "^0.73.2",
     "@react-native/typescript-config": "^0.73.1",
-    "@types/react": "^18.2.6",
+    "@types/react": "^18.2.45",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.6.3",
     "eslint": "^8.55.0",

--- a/packages/client-web/package.json
+++ b/packages/client-web/package.json
@@ -48,7 +48,7 @@
     "@types/google.maps": "^3.50.4",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.11.48",
-    "@types/react": "^18.2.6",
+    "@types/react": "^18.2.45",
     "@types/react-dom": "^18.0.6",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.26",

--- a/packages/client-web/package.json
+++ b/packages/client-web/package.json
@@ -48,7 +48,7 @@
     "@types/google.maps": "^3.50.4",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.11.48",
-    "@types/react": "^18.0.17",
+    "@types/react": "^18.2.6",
     "@types/react-dom": "^18.0.6",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.26",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -42,7 +42,7 @@
     "@storybook/addon-links": "^6.5.10",
     "@storybook/addons": "^6.5.10",
     "@storybook/react": "^6.5.10",
-    "@types/react": "^18.2.6",
+    "@types/react": "^18.2.45",
     "@types/react-dom": "^18.0.6",
     "@types/react-modal": "^3.13.1",
     "babel-loader": "^8.2.5",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -42,7 +42,7 @@
     "@storybook/addon-links": "^6.5.10",
     "@storybook/addons": "^6.5.10",
     "@storybook/react": "^6.5.10",
-    "@types/react": "^18.0.17",
+    "@types/react": "^18.2.6",
     "@types/react-dom": "^18.0.6",
     "@types/react-modal": "^3.13.1",
     "babel-loader": "^8.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7076,19 +7076,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.17":
-  version "18.0.17"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.17.tgz#4583d9c322d67efe4b39a935d223edcc7050ccf4"
-  integrity sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.2.6":
-  version "18.2.42"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.42.tgz#6f6b11a904f6d96dda3c2920328a97011a00aba7"
-  integrity sha512-c1zEr96MjakLYus/wPnuWDo1/zErfdU9rNsIGmE+NV71nx88FG9Ttgo5dqorXTu/LImX2f63WBP986gJkMPNbA==
+"@types/react@*", "@types/react@^18.2.6", "@types/react@~18.2.42":
+  version "18.2.45"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.45.tgz#253f4fac288e7e751ab3dc542000fb687422c15c"
+  integrity sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7076,7 +7076,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.6", "@types/react@~18.2.42":
+"@types/react@*", "@types/react@^18.2.45":
   version "18.2.45"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.45.tgz#253f4fac288e7e751ab3dc542000fb687422c15c"
   integrity sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==


### PR DESCRIPTION
* Kept getting these errors in `client-mobile`
<img width="1175" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/a823e096-5d0b-4936-a8bd-d1d9022b4f85">

* According to [this](https://stackoverflow.com/a/71916657) it's due to version conflicts
* Indeed `yarn why @types/react` shows two different versions.
<img width="984" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/997cf000-68d4-404d-87c3-af8644d954c1">

* This may just be an IDE issue, i.e. VS Code struggles to reconcile which version to use. Whereas the mobile app compiles and works without issue.