### PR TITLE
feat(client-mobile): add header to screens

### DIFF
--- a/packages/client-mobile/src/App/index.tsx
+++ b/packages/client-mobile/src/App/index.tsx
@@ -19,8 +19,8 @@ function App() {
     <SafeAreaView style={styles.wrapper}>
       <NavigationContainer>
         <View style={wrapperStyles}>
-          <Screens />
           <NavBar />
+          <Screens />
         </View>
       </NavigationContainer>
     </SafeAreaView>

--- a/packages/client-mobile/src/App/styles.ts
+++ b/packages/client-mobile/src/App/styles.ts
@@ -6,11 +6,11 @@ const styles = StyleSheet.create({
   },
   navContentNarrow: {
     flex: 1,
-    flexDirection: "column",
+    flexDirection: "column-reverse",
   },
   navContentWide: {
     flex: 1,
-    flexDirection: "row-reverse",
+    flexDirection: "row",
   },
 });
 

--- a/packages/client-mobile/src/screens/Home.tsx
+++ b/packages/client-mobile/src/screens/Home.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { Text, View } from "react-native";
+import { Text } from "react-native";
+
 import { ScreenProps } from "./types";
+import ScreenTemplate from "./ScreenTemplate";
 
 const HomeScreen = (_: ScreenProps<"home">) => {
   return (
-    <View>
-      <Text>Home</Text>
-    </View>
+    <ScreenTemplate>
+      <Text>Home Screen</Text>
+    </ScreenTemplate>
   );
 };
 

--- a/packages/client-mobile/src/screens/ScreenTemplate.tsx
+++ b/packages/client-mobile/src/screens/ScreenTemplate.tsx
@@ -1,0 +1,27 @@
+import React, { ReactNode } from "react";
+import { Text, View } from "react-native";
+import { useRoute } from "@react-navigation/native";
+
+import { screenConfigMap } from "./config";
+import { ScreenName } from "./types";
+
+type Props = {
+  children: ReactNode;
+};
+
+const ScreenTemplate = ({ children }: Props) => {
+  const route = useRoute();
+
+  const currentScreen = screenConfigMap[route.name as ScreenName];
+
+  return (
+    <View>
+      <View>
+        <Text>{currentScreen.title}</Text>
+      </View>
+      {children}
+    </View>
+  );
+};
+
+export default ScreenTemplate;

--- a/packages/client-mobile/src/screens/Settings.tsx
+++ b/packages/client-mobile/src/screens/Settings.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Text, View } from "react-native";
+
 import { ScreenProps } from "./types";
+import ScreenTemplate from "./ScreenTemplate";
 
 const SettingsScreen = (_: ScreenProps<"settings">) => {
   return (
-    <View>
-      <Text>Settings</Text>
-    </View>
+    <ScreenTemplate>
+      <Text>Settings Screen</Text>
+    </ScreenTemplate>
   );
 };
 


### PR DESCRIPTION
# Before

<img width="1220" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/617dfe57-87da-4513-9c30-9e2d2a7c6a1c">


# After

<img width="1221" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/1e298f01-03a6-466e-9dae-9652da5355b0">
