### PR TITLE
feat(client-mobile): add map to home screen

### DIFF
--- a/packages/client-mobile/ios/Podfile.lock
+++ b/packages/client-mobile/ios/Podfile.lock
@@ -944,6 +944,8 @@ PODS:
   - React-Mapbuffer (0.73.0):
     - glog
     - React-debug
+  - react-native-maps (1.8.4):
+    - React-Core
   - react-native-safe-area-context (4.8.2):
     - React-Core
   - React-nativeconfig (0.73.0)
@@ -1173,6 +1175,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector-modern`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
+  - react-native-maps (from `../node_modules/react-native-maps`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-nativeconfig (from `../node_modules/react-native/ReactCommon`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
@@ -1269,6 +1272,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   React-Mapbuffer:
     :path: "../node_modules/react-native/ReactCommon"
+  react-native-maps:
+    :path: "../node_modules/react-native-maps"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   React-nativeconfig:
@@ -1356,6 +1361,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 9f6fb9ed9f03a0fb961ab8dc2e0e0ee0dc729e77
   React-logger: 008caec0d6a587abc1e71be21bfac5ba1662fe6a
   React-Mapbuffer: 58fe558faf52ecde6705376700f848d0293d1cef
+  react-native-maps: e2b78affd8e90c807a87bd042dc6b1af2decbcf1
   react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   React-nativeconfig: a063483672b8add47a4875b0281e202908ff6747
   React-NativeModulesApple: 169506a5fd708ab22811f76ee06a976595c367a1

--- a/packages/client-mobile/package.json
+++ b/packages/client-mobile/package.json
@@ -20,6 +20,7 @@
     "@react-navigation/native": "^6.1.9",
     "react": "18.2.0",
     "react-native": "0.73.0",
+    "react-native-maps": "^1.8.4",
     "react-native-safe-area-context": "^4.8.2",
     "react-native-screens": "^3.29.0"
   },

--- a/packages/client-mobile/src/Map/index.tsx
+++ b/packages/client-mobile/src/Map/index.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useRef } from "react";
+import MapView from "react-native-maps";
+import styles from "./styles";
+
+// Melbourne, Victoria
+const initialCoords = {
+  latitude: -37.8136,
+  longitude: 144.9631,
+};
+
+export const Map = () => {
+  const region = {
+    latitude: initialCoords.latitude,
+    longitude: initialCoords.longitude,
+    latitudeDelta: 0.1,
+    longitudeDelta: 0.1,
+  };
+
+  return <MapView style={styles.wrapper} initialRegion={region} />;
+};

--- a/packages/client-mobile/src/Map/styles.ts
+++ b/packages/client-mobile/src/Map/styles.ts
@@ -1,0 +1,10 @@
+import { Dimensions, StyleSheet } from "react-native";
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    width: "100%",
+  },
+});
+
+export default styles;

--- a/packages/client-mobile/src/screens/Home.tsx
+++ b/packages/client-mobile/src/screens/Home.tsx
@@ -3,11 +3,12 @@ import { Text } from "react-native";
 
 import { ScreenProps } from "./types";
 import ScreenTemplate from "./ScreenTemplate";
+import { Map } from "../Map";
 
 const HomeScreen = (_: ScreenProps<"home">) => {
   return (
     <ScreenTemplate>
-      <Text>Home Screen</Text>
+      <Map />
     </ScreenTemplate>
   );
 };

--- a/packages/client-mobile/src/screens/ScreenTemplate/index.tsx
+++ b/packages/client-mobile/src/screens/ScreenTemplate/index.tsx
@@ -2,8 +2,10 @@ import React, { ReactNode } from "react";
 import { Text, View } from "react-native";
 import { useRoute } from "@react-navigation/native";
 
-import { screenConfigMap } from "./config";
-import { ScreenName } from "./types";
+import styles from "./styles";
+
+import { screenConfigMap } from "../config";
+import { ScreenName } from "../types";
 
 type Props = {
   children: ReactNode;
@@ -15,7 +17,7 @@ const ScreenTemplate = ({ children }: Props) => {
   const currentScreen = screenConfigMap[route.name as ScreenName];
 
   return (
-    <View>
+    <View style={styles.wrapper}>
       <View>
         <Text>{currentScreen.title}</Text>
       </View>

--- a/packages/client-mobile/src/screens/ScreenTemplate/styles.ts
+++ b/packages/client-mobile/src/screens/ScreenTemplate/styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from "react-native";
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+  },
+});
+
+export default styles;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6743,6 +6743,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/geojson@^7946.0.10":
+  version "7946.0.13"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.13.tgz#e6e77ea9ecf36564980a861e24e62a095988775e"
+  integrity sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==
+
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -21651,6 +21656,13 @@ react-modal@^3.10.1:
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
+
+react-native-maps@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.8.4.tgz#41f91b597101ec58729c6cbb46dc347f52af68d5"
+  integrity sha512-PL7XX4dddTZB7PHDY0qslsJls5X2uRL2FSfUmiH4CFXIJ2l8QTaeWM6BLwnBswNUL6p4lQQeXuiATAhaRLHT6g==
+  dependencies:
+    "@types/geojson" "^7946.0.10"
 
 react-native-safe-area-context@^4.8.2:
   version "4.8.2"


### PR DESCRIPTION
# iOS
<img width="1433" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/47004709-21ce-4238-94c8-7e42c10ccf88">

# Android
Add later like [this](https://github.com/react-native-maps/react-native-maps/blob/HEAD/docs/installation.md#android) after working out how to avoid committing the API key