### PR TITLE
refactor(client-mobile): add responsive styles hook

### DIFF
--- a/packages/client-mobile/src/App/NavBar/index.tsx
+++ b/packages/client-mobile/src/App/NavBar/index.tsx
@@ -3,7 +3,7 @@ import { View, Text } from "react-native";
 
 import styles from "./styles";
 
-import { useIsNarrow } from "../../dimensions";
+import { useScreenWidth } from "../../dimensions";
 import GoToScreenButton from "./GoToScreenButton";
 import HelpButton from "./HelpButton";
 
@@ -12,28 +12,28 @@ type Props = {
 };
 
 const NavBar = ({ onHelpClick }: Props) => {
-  const isNarrow = useIsNarrow();
+  const screenWidth = useScreenWidth();
 
-  if (isNarrow) {
+  if (["md", "lg", "xl"].includes(screenWidth)) {
     return (
-      <View style={styles.wrapperH}>
-        <HelpButton onPress={onHelpClick} />
-        <GoToScreenButton name="home" />
-        <GoToScreenButton name="settings" />
+      <View style={styles.wrapperV}>
+        <View>
+          <Text>Quoll</Text>
+          <GoToScreenButton name="home" />
+        </View>
+        <View>
+          <GoToScreenButton name="settings" />
+          <HelpButton onPress={onHelpClick} />
+        </View>
       </View>
     );
   }
 
   return (
-    <View style={styles.wrapperV}>
-      <View>
-        <Text>Quoll</Text>
-        <GoToScreenButton name="home" />
-      </View>
-      <View>
-        <GoToScreenButton name="settings" />
-        <HelpButton onPress={onHelpClick} />
-      </View>
+    <View style={styles.wrapperH}>
+      <HelpButton onPress={onHelpClick} />
+      <GoToScreenButton name="home" />
+      <GoToScreenButton name="settings" />
     </View>
   );
 };

--- a/packages/client-mobile/src/App/index.tsx
+++ b/packages/client-mobile/src/App/index.tsx
@@ -2,11 +2,10 @@ import React, { useState } from "react";
 import { SafeAreaView, View } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 
-import styles from "./styles";
+import { useStyles } from "./styles";
 
 import NavBar from "./NavBar";
 import Screens from "../screens/Screens";
-import { useIsNarrow } from "../dimensions";
 import WelcomeModal from "../WelcomeModal";
 
 function App() {
@@ -20,16 +19,12 @@ function App() {
     closeWelcomeModal();
   };
 
-  const isNarrow = useIsNarrow();
-
-  const wrapperStyles = isNarrow
-    ? styles.navContentNarrow
-    : styles.navContentWide;
+  const styles = useStyles();
 
   return (
     <SafeAreaView style={styles.wrapper}>
       <NavigationContainer>
-        <View style={wrapperStyles}>
+        <View style={styles.navContent}>
           <NavBar onHelpClick={openWelcomeModal} />
           <Screens />
         </View>

--- a/packages/client-mobile/src/App/styles.ts
+++ b/packages/client-mobile/src/App/styles.ts
@@ -1,17 +1,27 @@
 import { StyleSheet } from "react-native";
+import { useResponsiveStyles } from "../dimensions";
 
-const styles = StyleSheet.create({
+const stylesDefault = StyleSheet.create({
   wrapper: {
     flex: 1,
   },
-  navContentNarrow: {
+  navContent: {
     flex: 1,
     flexDirection: "column-reverse",
   },
-  navContentWide: {
+});
+
+const stylesWide = StyleSheet.create({
+  ...stylesDefault,
+  navContent: {
     flex: 1,
     flexDirection: "row",
   },
 });
 
-export default styles;
+export const useStyles = () =>
+  useResponsiveStyles({
+    xs: stylesDefault,
+    sm: stylesDefault,
+    md: stylesWide,
+  });

--- a/packages/client-mobile/src/dimensions/index.ts
+++ b/packages/client-mobile/src/dimensions/index.ts
@@ -107,22 +107,3 @@ export const useResponsiveStyles = <Name extends string>(
 
   return stylesMap_[screenWidth];
 };
-
-/**
- * Returns whether the screen is narrow or not.
- *
- * @remarks
- *
- * Narrow is defined by screen breakpoint values from the design system.
- *
- * @returns
- *
- * `true` if the screen is narrow
- *
- * `false` if the screen is wide
- */
-export const useIsNarrow = () => {
-  const { width } = useWindowDimensions();
-
-  return width <= breakpoints.md;
-};

--- a/packages/client-mobile/src/dimensions/index.ts
+++ b/packages/client-mobile/src/dimensions/index.ts
@@ -1,12 +1,111 @@
-import { useWindowDimensions } from "react-native";
+import {
+  ImageStyle,
+  TextStyle,
+  ViewStyle,
+  useWindowDimensions,
+} from "react-native";
+
+type ScreenWidthLabel = "xs" | "sm" | "md" | "lg" | "xl";
 
 // TODO get these from ui-components or a new shared package
-const breakpoints = {
+const breakpoints: Record<ScreenWidthLabel, number> = {
   xs: 0,
   sm: 544,
   md: 768,
   lg: 992,
   xl: 1281,
+};
+
+/**
+ * Watches the screen width and returns the label it most closely matches.
+ *
+ * We match to the nearest label _below_ the current screen width. For
+ * example, if the screen width is between `md` and `lg` then we match on `md`.
+ *
+ * @returns the screen width label.
+ */
+export const useScreenWidth = (): ScreenWidthLabel => {
+  const { width } = useWindowDimensions();
+
+  if (width >= breakpoints.xl) return "xl";
+  if (width >= breakpoints.lg) return "lg";
+  if (width >= breakpoints.md) return "md";
+  if (width >= breakpoints.sm) return "sm";
+
+  return "xs";
+};
+
+/**
+ * An individual style object applied to a `View`, `Text`, `Image` etc.
+ */
+type Style = ViewStyle | TextStyle | ImageStyle;
+
+/**
+ * The styles object created by `StyleSheet.create`. We use a generic `Name` to
+ * enforce the same key names when using `useResponsiveStyles`.
+ */
+type Styles<Name extends string> = Record<Name, Style>;
+
+/**
+ * The input param type for `useResponsiveStyles`. At minimum `xs` and `sm` are
+ * required for responsive behaviour.
+ */
+type StylesMap<Name extends string> =
+  | {
+      xs: Styles<Name>;
+      sm: Styles<Name>;
+      md?: never;
+      lg?: never;
+      xl?: never;
+    }
+  | {
+      xs: Styles<Name>;
+      sm: Styles<Name>;
+      md: Styles<Name>;
+      lg?: never;
+      xl?: never;
+    }
+  | {
+      xs: Styles<Name>;
+      sm: Styles<Name>;
+      md: Styles<Name>;
+      lg: Styles<Name>;
+      xl?: never;
+    }
+  | {
+      xs: Styles<Name>;
+      sm: Styles<Name>;
+      md: Styles<Name>;
+      lg: Styles<Name>;
+      xl: Styles<Name>;
+    };
+
+/**
+ * Returns the styles for the current screen width.
+ *
+ * @param stylesMap a map of styles for each screen width.
+ *
+ * @returns the styles for the current screen width.
+ *
+ * @remarks
+ *
+ * Both `xs` and `sm` are required. If there are no distinct styles for `sm` or
+ * above then this hook is not required. Just define static styles.
+ */
+export const useResponsiveStyles = <Name extends string>(
+  stylesMap: StylesMap<Name>
+) => {
+  const screenWidth = useScreenWidth();
+
+  const stylesMap_ = {
+    xs: stylesMap.xs,
+    sm: stylesMap.sm,
+    md: stylesMap.md ?? stylesMap.sm,
+    lg: stylesMap.lg ?? stylesMap.md ?? stylesMap.sm,
+    xl: stylesMap.xl ?? stylesMap.lg ?? stylesMap.md ?? stylesMap.sm,
+  };
+
+  return stylesMap_[screenWidth];
 };
 
 /**

--- a/packages/client-mobile/src/dimensions/index.ts
+++ b/packages/client-mobile/src/dimensions/index.ts
@@ -41,8 +41,17 @@ export const useScreenWidth = (): ScreenWidthLabel => {
 type Style = ViewStyle | TextStyle | ImageStyle;
 
 /**
- * The styles object created by `StyleSheet.create`. We use a generic `Name` to
- * enforce the same key names when using `useResponsiveStyles`.
+ * The styles object created by `StyleSheet.create`. The generic `Name`
+ * represents the key name, e.g. `wrapper` in this object
+ *
+ * ```typescript
+ * wrapper: {
+ *   flex: 1,
+ * }
+ * ```
+ *
+ * Using a generic like this enforces the same key names be used in the param
+ * for `useResponsiveStyles`.
  */
 type Styles<Name extends string> = Record<Name, Style>;
 
@@ -91,6 +100,9 @@ type StylesMap<Name extends string> =
  *
  * Both `xs` and `sm` are required. If there are no distinct styles for `sm` or
  * above then this hook is not required. Just define static styles.
+ *
+ * If styles are not defined for the current screen width then the styles for
+ * the first matching width below is used.
  */
 export const useResponsiveStyles = <Name extends string>(
   stylesMap: StylesMap<Name>

--- a/packages/client-mobile/src/screens/Home/index.tsx
+++ b/packages/client-mobile/src/screens/Home/index.tsx
@@ -1,28 +1,23 @@
 import React from "react";
 import { View } from "react-native";
 
-import styles from "./styles";
+import { useStyles } from "./styles";
 
 import { ScreenProps } from "../types";
 import ScreenTemplate from "../ScreenTemplate";
 import { Map } from "../../Map";
 import { DateBar } from "../../date-bar";
-import { useIsNarrow } from "../../dimensions";
 
 const HomeScreen = (_: ScreenProps<"home">) => {
-  const isNarrow = useIsNarrow();
-
-  const wrapperStyles = isNarrow ? styles.wrapperNarrow : styles.wrapperWide;
-  const mapStyles = styles.map;
-  const sideBarStyles = isNarrow ? styles.sideBarNarrow : styles.sideBarWide;
+  const styles = useStyles();
 
   return (
     <ScreenTemplate>
-      <View style={wrapperStyles}>
-        <View style={mapStyles}>
+      <View style={styles.wrapper}>
+        <View style={styles.map}>
           <Map />
         </View>
-        <View style={sideBarStyles}>
+        <View style={styles.sideBar}>
           <DateBar onDateChange={() => {}} />
         </View>
       </View>

--- a/packages/client-mobile/src/screens/Home/styles.ts
+++ b/packages/client-mobile/src/screens/Home/styles.ts
@@ -1,20 +1,32 @@
 import { StyleSheet } from "react-native";
+import { useResponsiveStyles } from "../../dimensions";
 
-const styles = StyleSheet.create({
-  wrapperNarrow: {
+const stylesDefault = StyleSheet.create({
+  wrapper: {
     flex: 1,
   },
-  wrapperWide: {
+  map: {
+    flex: 1,
+  },
+  sideBar: {},
+});
+
+const stylesWide = StyleSheet.create({
+  wrapper: {
     flexDirection: "row-reverse",
     flex: 1,
   },
   map: {
     flex: 1,
   },
-  sideBarNarrow: {},
-  sideBarWide: {
+  sideBar: {
     maxWidth: 300,
   },
 });
 
-export default styles;
+export const useStyles = () =>
+  useResponsiveStyles({
+    xs: stylesDefault,
+    sm: stylesDefault,
+    md: stylesWide,
+  });


### PR DESCRIPTION
* Currently, responsive styles are managed manually in each component.
* With this change, `useResponsiveStyles` can be called with styles for each screen width. Then the styles for the current width is returned.
* Usage is consistent with a static `styles`, e.g.
```tsx
const styles = StyleSheet.create({ ... });

<View style={styles.wrapper}>
```
* Later, if styles need to be responsive then just replace the static styles with responsive styles
```tsx
const styles = useResponsiveStyles({ xs: { ... },  sm: { ... } });

<View style={styles.wrapper}>
```