### PR TITLE
feat(client-mobile): add Google Maps for Android

### DIFF
--- a/packages/client-mobile/android/app/build.gradle
+++ b/packages/client-mobile/android/app/build.gradle
@@ -81,6 +81,13 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+
+        // Get property values, e.g. API keys
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file("local.properties").newDataInputStream())
+    
+        // Set the values to variables
+        resValue "string", "GOOGLE_MAPS_API_KEY", "\"${properties.getProperty("GOOGLE_MAPS_API_KEY")}\""
     }
     signingConfigs {
         debug {

--- a/packages/client-mobile/android/app/src/debug/AndroidManifest.xml
+++ b/packages/client-mobile/android/app/src/debug/AndroidManifest.xml
@@ -5,5 +5,5 @@
     <application
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning"/>
+        tools:ignore="GoogleAppIndexingWarning" />
 </manifest>

--- a/packages/client-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/client-mobile/android/app/src/main/AndroidManifest.xml
@@ -1,25 +1,25 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.INTERNET" />
 
-    <application
-      android:name=".MainApplication"
+  <application
+    android:name=".MainApplication"
+    android:label="@string/app_name"
+    android:icon="@mipmap/ic_launcher"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:allowBackup="false"
+    android:theme="@style/AppTheme">
+    <activity
+      android:name=".MainActivity"
       android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
-      android:theme="@style/AppTheme">
-      <activity
-        android:name=".MainActivity"
-        android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-        android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize"
-        android:exported="true">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
-    </application>
+      android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+      android:launchMode="singleTask"
+      android:windowSoftInputMode="adjustResize"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
 </manifest>

--- a/packages/client-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/client-mobile/android/app/src/main/AndroidManifest.xml
@@ -21,5 +21,8 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+    <meta-data
+      android:name="com.google.android.geo.API_KEY"
+      android:value="@string/GOOGLE_MAPS_API_KEY" />
   </application>
 </manifest>


### PR DESCRIPTION
* Android uses Google maps, which needs an API key
* This is stored in a `local.properties` file, which is in `.gitignore`
```
GOOGLE_MAPS_API_KEY=xxxxxxxxxx
```
* We then extract it in the gradle file and add it to the manifest