### PR TITLE
chore: create an interactive start shell script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "packages/*"
   ],
   "scripts": {
-    "start": "node scripts/start.js",
+    "start": "./scripts/start.sh",
     "release": "cross-env HUSKY_BYPASS=true lerna publish --conventional-commits --yes",
     "clean-build": "lerna exec -- rm -rf ./build ./dist && rm -rf ./build ./dist",
     "clean-node-modules": "lerna exec -- rm -rf ./node_modules && rm -rf ./node_modules",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -10,7 +10,7 @@ const PACKAGES = [
 
 if (process.argv.length <= 2) {
   console.error(
-    "Error: Must specify the package to run, e.g. 'yarn start api'.",
+    `Error: Must specify the package to run, e.g. 'yarn start ${PACKAGES[0]}'.`,
   );
   process.exit(1);
 }

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-options=("🗃️  api" "📱 client-mobile" "🌐 client-web" "🧩 ui-components", "🎨 ui-primitives")
+options=("🗃️  api" "📱 client-mobile" "🌐 client-web" "🧩 ui-components" "🎨 ui-primitives")
 selected_option=0
 
 while true; do

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-options=("api" "client-mobile" "client-web" "ui-components")
+options=("🗃️  api" "📱 client-mobile" "🌐 client-web" "🧩 ui-components", "🎨 ui-primitives")
 selected_option=0
 
 while true; do

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 options=("api" "client-mobile" "client-web" "ui-components")
-selected_option=0  # Initialize with the default value
+selected_option=0
 
 while true; do
     clear
@@ -39,21 +39,6 @@ done
 
 selected_option_label="${options[selected_option]}"
 
-case $selected_option_label in
-    "api")
-        echo "Executing script for "${selected_option_label}""
-        # Add your api script here
-        ;;
-    "client-mobile")
-        echo "Executing script for "${selected_option_label}""
-        # Add your client-mobile script here
-        ;;
-    "client-web")
-        echo "Executing script for "${selected_option_label}""
-        # Add your client-web script here
-        ;;
-    "ui-components")
-        echo "Executing script for "${selected_option_label}""
-        # Add your ui-components script here
-        ;;
-esac
+echo "Running "${selected_option_label}"..."
+
+yarn start "${selected_option_label}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,6 +14,9 @@ while true; do
         fi
     done
 
+    echo ""
+    echo "(type q to quit)"
+
     read -rsn1 key
 
     case "$key" in

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -37,21 +37,23 @@ while true; do
     esac
 done
 
-case "${options[selected_option]}" in
+selected_option_label="${options[selected_option]}"
+
+case $selected_option_label in
     "api")
-        echo "Executing script for api"
+        echo "Executing script for "${selected_option_label}""
         # Add your api script here
         ;;
     "client-mobile")
-        echo "Executing script for client-mobile"
+        echo "Executing script for "${selected_option_label}""
         # Add your client-mobile script here
         ;;
     "client-web")
-        echo "Executing script for client-web"
+        echo "Executing script for "${selected_option_label}""
         # Add your client-web script here
         ;;
     "ui-components")
-        echo "Executing script for ui-components"
+        echo "Executing script for "${selected_option_label}""
         # Add your ui-components script here
         ;;
 esac

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -41,4 +41,4 @@ selected_option_label="${options[selected_option]}"
 
 echo "Running "${selected_option_label}"..."
 
-yarn start "${selected_option_label}"
+node scripts/start.js "${selected_option_label}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -43,9 +43,10 @@ while true; do
 done
 
 selected_option_label="${options[selected_option]}"
+selected_option_emoji="${emojis[selected_option]}"
 
 clear
 
-echo "Running "${selected_option_label}"..."
+echo "Running "${selected_option_emoji}" "${selected_option_label}"..."
 
 node scripts/start.js "${selected_option_label}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,11 +7,15 @@ selected_option=0
 while true; do
     clear
     echo "Select a script to run:"
+
     for ((i=0; i<${#options[@]}; i++)); do
+        option=${options[i]}
+        emoji=${emojis[i]}
+
         if [ "$i" -eq "$selected_option" ]; then
-            echo "* ${emojis[i]} ${options[i]}"
+            echo "* $emoji $option"
         else
-            echo "  ${emojis[i]} ${options[i]}"
+            echo "  $emoji $option"
         fi
     done
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -44,6 +44,8 @@ done
 
 selected_option_label="${options[selected_option]}"
 
+clear
+
 echo "Running "${selected_option_label}"..."
 
 node scripts/start.js "${selected_option_label}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+options=("api" "client-mobile" "client-web" "ui-components")
+selected_option=0  # Initialize with the default value
+
+while true; do
+    clear
+    echo "Select a script to run:"
+    for ((i=0; i<${#options[@]}; i++)); do
+        if [ "$i" -eq "$selected_option" ]; then
+            echo "* ${options[i]}"
+        else
+            echo "  ${options[i]}"
+        fi
+    done
+
+    read -rsn1 key
+
+    case "$key" in
+        "q")  # Quit
+            exit 0
+            ;;
+        "A")  # Arrow Up
+            ((selected_option--))
+            [ "$selected_option" -lt 0 ] && selected_option=$((${#options[@]} - 1))
+            ;;
+        "B")  # Arrow Down
+            ((selected_option++))
+            [ "$selected_option" -ge "${#options[@]}" ] && selected_option=0
+            ;;
+        "")   # Enter key
+            break
+            ;;
+    esac
+done
+
+case "${options[selected_option]}" in
+    "api")
+        echo "Executing script for api"
+        # Add your api script here
+        ;;
+    "client-mobile")
+        echo "Executing script for client-mobile"
+        # Add your client-mobile script here
+        ;;
+    "client-web")
+        echo "Executing script for client-web"
+        # Add your client-web script here
+        ;;
+    "ui-components")
+        echo "Executing script for ui-components"
+        # Add your ui-components script here
+        ;;
+esac

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-options=("🗃️  api" "📱 client-mobile" "🌐 client-web" "🧩 ui-components" "🎨 ui-primitives")
+emojis=("🗃️ " "📱" "🌐" "🧩" "🎨")
+options=("api" "client-mobile" "client-web" "ui-components" "ui-primitives")
 selected_option=0
 
 while true; do
@@ -8,9 +9,9 @@ while true; do
     echo "Select a script to run:"
     for ((i=0; i<${#options[@]}; i++)); do
         if [ "$i" -eq "$selected_option" ]; then
-            echo "* ${options[i]}"
+            echo "* ${emojis[i]} ${options[i]}"
         else
-            echo "  ${options[i]}"
+            echo "  ${emojis[i]} ${options[i]}"
         fi
     done
 


### PR DESCRIPTION
# Background
- Current development process is to type out, e.g., `yarn start client-mobile` in the root dir
- Lots of key strokes and easy to fumble

# Changes
- Created an interactive script that presents options to choose from
<img width="278" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/fd41e36c-90b6-4759-b096-d072eb1c8902">

- Built almost entirely with ChatGPT's [help](https://chat.openai.com/share/76b7e415-38d1-4840-b683-2cee9ae437a0)
- Demo
  - `yarn start`, cycle through options the type `q` to quite
  - `yarn start` again, cycle through options and select one 

https://github.com/mzogheib/quoll/assets/10183584/791b02cb-197a-408c-8491-668c3cdcb91b

