### PR TITLE
feat(client-mobile): persist permissions choice

### DIFF
--- a/packages/client-mobile/ios/Podfile.lock
+++ b/packages/client-mobile/ios/Podfile.lock
@@ -72,6 +72,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.73.0)
   - hermes-engine/Pre-built (0.73.0)
   - libevent (2.1.12)
+  - MMKV (1.2.13):
+    - MMKVCore (~> 1.2.13)
+  - MMKVCore (1.2.16)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2022.05.16.00):
     - boost
@@ -952,6 +955,9 @@ PODS:
     - React-Core
   - react-native-maps (1.8.4):
     - React-Core
+  - react-native-mmkv-storage (0.9.1):
+    - MMKV (= 1.2.13)
+    - React-Core
   - react-native-safe-area-context (4.8.2):
     - React-Core
   - React-nativeconfig (0.73.0)
@@ -1185,6 +1191,7 @@ DEPENDENCIES:
   - react-native-date-picker (from `../node_modules/react-native-date-picker`)
   - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
   - react-native-maps (from `../node_modules/react-native-maps`)
+  - react-native-mmkv-storage (from `../node_modules/react-native-mmkv-storage`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-nativeconfig (from `../node_modules/react-native/ReactCommon`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
@@ -1222,6 +1229,8 @@ SPEC REPOS:
     - FlipperKit
     - fmt
     - libevent
+    - MMKV
+    - MMKVCore
     - OpenSSL-Universal
     - SocketRocket
 
@@ -1289,6 +1298,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/geolocation"
   react-native-maps:
     :path: "../node_modules/react-native-maps"
+  react-native-mmkv-storage:
+    :path: "../node_modules/react-native-mmkv-storage"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   React-nativeconfig:
@@ -1354,6 +1365,8 @@ SPEC CHECKSUMS:
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 34304f8c6e8fa68f63a5fe29af82f227d817d7a7
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
+  MMKV: aac95d817a100479445633f2b3ed8961b4ac5043
+  MMKVCore: 9cfef4c48c6c46f66226fc2e4634d78490206a48
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 5e3631b27c08716986980ef23eed8abdee1cdcaf
@@ -1380,6 +1393,7 @@ SPEC CHECKSUMS:
   react-native-date-picker: 90d1d60802a20085125657940b944f2bb4e5c113
   react-native-geolocation: ef66fb798d96284c6043f0b16c15d9d1d4955db4
   react-native-maps: e2b78affd8e90c807a87bd042dc6b1af2decbcf1
+  react-native-mmkv-storage: cfb6854594cfdc5f7383a9e464bb025417d1721c
   react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   React-nativeconfig: a063483672b8add47a4875b0281e202908ff6747
   React-NativeModulesApple: 169506a5fd708ab22811f76ee06a976595c367a1

--- a/packages/client-mobile/ios/client_mobile/Info.plist
+++ b/packages/client-mobile/ios/client_mobile/Info.plist
@@ -22,6 +22,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -33,6 +35,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Allow access to your photos and videos.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>MaterialIcons.ttf</string>
@@ -50,10 +54,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>LSApplicationCategoryType</key>
-	<string></string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Allow access to your photos and videos.</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/packages/client-mobile/package.json
+++ b/packages/client-mobile/package.json
@@ -24,6 +24,7 @@
     "react-native": "0.73.0",
     "react-native-date-picker": "^4.3.5",
     "react-native-maps": "^1.8.4",
+    "react-native-mmkv-storage": "^0.9.1",
     "react-native-safe-area-context": "^4.8.2",
     "react-native-screens": "^3.29.0",
     "react-native-vector-icons": "^10.0.3",

--- a/packages/client-mobile/src/modules/media/logic/index.ts
+++ b/packages/client-mobile/src/modules/media/logic/index.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Platform, PermissionsAndroid } from "react-native";
 import { CameraRoll } from "@react-native-camera-roll/camera-roll";
 import { promptAllowAccess } from "@modules/alert/logic";
+import { useStorage } from "@modules/storage/logic";
 
 const checkIsPermittedIOS = async () =>
   !!(await CameraRoll.getPhotos({ first: 1 }));
@@ -39,7 +40,10 @@ const checkIsPermitted = async () => {
 };
 
 export const useMedia = () => {
-  const [isConnected, setIsConnected] = useState(false);
+  const { value: isConnected, setValue: setIsConnected } = useStorage(
+    "isConnected",
+    false,
+  );
   const [isConnecting, setIsConnecting] = useState(false);
 
   const checkPermissionAndConnect = useCallback(async () => {
@@ -50,11 +54,6 @@ export const useMedia = () => {
 
     return isPermitted;
   }, []);
-
-  // Check if permission has previously been granted.
-  useEffect(() => {
-    checkPermissionAndConnect();
-  }, [checkPermissionAndConnect]);
 
   const connect = async () => {
     const isPermitted = await checkPermissionAndConnect();

--- a/packages/client-mobile/src/modules/media/logic/index.ts
+++ b/packages/client-mobile/src/modules/media/logic/index.ts
@@ -40,10 +40,7 @@ const checkIsPermitted = async () => {
 };
 
 export const useMedia = () => {
-  const { value: isConnected, setValue: setIsConnected } = usePersistedState(
-    "isConnected",
-    false,
-  );
+  const [isConnected, setIsConnected] = usePersistedState("isConnected", false);
   const [isConnecting, setIsConnecting] = useState(false);
 
   const checkPermissionAndConnect = useCallback(async () => {

--- a/packages/client-mobile/src/modules/media/logic/index.ts
+++ b/packages/client-mobile/src/modules/media/logic/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Platform, PermissionsAndroid } from "react-native";
 import { CameraRoll } from "@react-native-camera-roll/camera-roll";
 import { promptAllowAccess } from "@modules/alert/logic";

--- a/packages/client-mobile/src/modules/media/logic/index.ts
+++ b/packages/client-mobile/src/modules/media/logic/index.ts
@@ -58,7 +58,7 @@ export const useMedia = () => {
     if (!isConnected) return;
 
     checkPermissionAndConnect();
-  }, []);
+  }, [checkPermissionAndConnect]);
 
   const connect = async () => {
     const isPermitted = await checkPermissionAndConnect();

--- a/packages/client-mobile/src/modules/media/logic/index.ts
+++ b/packages/client-mobile/src/modules/media/logic/index.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Platform, PermissionsAndroid } from "react-native";
 import { CameraRoll } from "@react-native-camera-roll/camera-roll";
 import { promptAllowAccess } from "@modules/alert/logic";
-import { useStorage } from "@modules/storage/logic";
+import { usePersistedState } from "@modules/persisted-state/logic";
 
 const checkIsPermittedIOS = async () =>
   !!(await CameraRoll.getPhotos({ first: 1 }));
@@ -40,7 +40,7 @@ const checkIsPermitted = async () => {
 };
 
 export const useMedia = () => {
-  const { value: isConnected, setValue: setIsConnected } = useStorage(
+  const { value: isConnected, setValue: setIsConnected } = usePersistedState(
     "isConnected",
     false,
   );

--- a/packages/client-mobile/src/modules/media/logic/index.ts
+++ b/packages/client-mobile/src/modules/media/logic/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Platform, PermissionsAndroid } from "react-native";
 import { CameraRoll } from "@react-native-camera-roll/camera-roll";
 import { promptAllowAccess } from "@modules/alert/logic";
@@ -50,6 +50,14 @@ export const useMedia = () => {
     setIsConnecting(false);
 
     return isPermitted;
+  }, []);
+
+  // User may have connected photos but then, via the app settings in the OS,
+  // denied permissions to photos. This will disconnect photos if that's the case.
+  useEffect(() => {
+    if (!isConnected) return;
+
+    checkPermissionAndConnect();
   }, []);
 
   const connect = async () => {

--- a/packages/client-mobile/src/modules/persisted-state/logic/index.ts
+++ b/packages/client-mobile/src/modules/persisted-state/logic/index.ts
@@ -3,7 +3,7 @@ import { MMKVLoader, useMMKVStorage } from "react-native-mmkv-storage";
 const MMKV = new MMKVLoader().initialize();
 
 /**
- * Returns a stateful value and a function to update it. Perists the value
+ * Returns a stateful value and a function to update it. Persists the value
  * between app launches.
  *
  * @param key a unique key for the persisted value

--- a/packages/client-mobile/src/modules/persisted-state/logic/index.ts
+++ b/packages/client-mobile/src/modules/persisted-state/logic/index.ts
@@ -2,11 +2,19 @@ import { MMKVLoader, useMMKVStorage } from "react-native-mmkv-storage";
 
 const MMKV = new MMKVLoader().initialize();
 
+/**
+ * Returns a stateful value and a function to update it. Perists the value
+ * between app launches.
+ *
+ * @param key a unique key for the persisted value
+ * @param initialValue the initial value
+ * @returns a tuple of the value and update function
+ */
 export const usePersistedState = <V>(
   key: string,
-  defaultValue: V,
+  initialValue: V,
 ): [V, (newValue: V) => void] => {
-  const [value, setValue] = useMMKVStorage(key, MMKV, defaultValue);
+  const [value, setValue] = useMMKVStorage(key, MMKV, initialValue);
 
   return [value, setValue];
 };

--- a/packages/client-mobile/src/modules/persisted-state/logic/index.ts
+++ b/packages/client-mobile/src/modules/persisted-state/logic/index.ts
@@ -2,8 +2,11 @@ import { MMKVLoader, useMMKVStorage } from "react-native-mmkv-storage";
 
 const MMKV = new MMKVLoader().initialize();
 
-export const usePersistedState = <V>(key: string, defaultValue: V) => {
+export const usePersistedState = <V>(
+  key: string,
+  defaultValue: V,
+): [V, (newValue: V) => void] => {
   const [value, setValue] = useMMKVStorage(key, MMKV, defaultValue);
 
-  return { value, setValue };
+  return [value, setValue];
 };

--- a/packages/client-mobile/src/modules/persisted-state/logic/index.ts
+++ b/packages/client-mobile/src/modules/persisted-state/logic/index.ts
@@ -2,7 +2,7 @@ import { MMKVLoader, useMMKVStorage } from "react-native-mmkv-storage";
 
 const MMKV = new MMKVLoader().initialize();
 
-export const useStorage = <V>(key: string, defaultValue: V) => {
+export const usePersistedState = <V>(key: string, defaultValue: V) => {
   const [value, setValue] = useMMKVStorage(key, MMKV, defaultValue);
 
   return { value, setValue };

--- a/packages/client-mobile/src/modules/storage/logic/index.ts
+++ b/packages/client-mobile/src/modules/storage/logic/index.ts
@@ -1,0 +1,9 @@
+import { MMKVLoader, useMMKVStorage } from "react-native-mmkv-storage";
+
+const MMKV = new MMKVLoader().initialize();
+
+export const useStorage = <V>(key: string, defaultValue: V) => {
+  const [value, setValue] = useMMKVStorage(key, MMKV, defaultValue);
+
+  return { value, setValue };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5944,6 +5944,7 @@ __metadata:
     react-native: "npm:0.73.0"
     react-native-date-picker: "npm:^4.3.5"
     react-native-maps: "npm:^1.8.4"
+    react-native-mmkv-storage: "npm:^0.9.1"
     react-native-safe-area-context: "npm:^4.8.2"
     react-native-screens: "npm:^3.29.0"
     react-native-vector-icons: "npm:^10.0.3"
@@ -28787,6 +28788,17 @@ __metadata:
     react-native-web:
       optional: true
   checksum: db1ae141da2c4295a40417262b9bd32fc9feeb4d5d449642cd8d28e23fd173cb6f0306179e4345e259b1d55e2b5def6ac8af79f7cdd972e3b175ef15c2a879e8
+  languageName: node
+  linkType: hard
+
+"react-native-mmkv-storage@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "react-native-mmkv-storage@npm:0.9.1"
+  peerDependencies:
+    react-native: "*"
+  bin:
+    mmkv-link: autolink/postlink/run.js
+  checksum: fe90039178c6be0935e5d205954e0b7e14dcbea67d22fbd486ecd59d6a6f5742f6d9dfbf23caef680743e2218cc4f8db987d92673d160719907418ccb065c394
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Background
- Currently, the media permissions are checked on initial render of the call to `useMedia`
- This is to check if the user has previously given permission
- `@react-native-camera-roll/camera-roll` doesn't provide a direct mechanism for this so it's simulated via a call to `getPhotos`
- But on initial launch, that will display the native "Allow access to your photos" alert, even though the user did not click Connect
- This is not desirable
<img width="300" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/9576ebff-725f-4d82-823f-a8d2c6827ba1">


# Changes
- If the user has not previously connected photos then don't do this check
- When they connect photos, store `isConnected` to persisted state.
- Later, on relaunch of the app, do the permissions check only if `isConnected: true`. This ensures removal of permissions via the OS is sync'd with `isConnected`