### PR TITLE
feat(client-mobile): add settings for location access

### DIFF
--- a/packages/client-mobile/src/components/FeedSettings/index.tsx
+++ b/packages/client-mobile/src/components/FeedSettings/index.tsx
@@ -6,6 +6,8 @@ import { ReactNode } from "react";
 type Props = {
   title: string;
   url?: string;
+  connectLabel?: string;
+  disconnectLabel?: string;
   isConnected: boolean;
   isConnecting: boolean;
   imageConnected: ReactNode;
@@ -16,6 +18,8 @@ type Props = {
 
 const FeedSettings = ({
   title,
+  connectLabel = "Connect",
+  disconnectLabel = "Disconnect",
   isConnected,
   isConnecting,
   imageConnected,
@@ -23,7 +27,7 @@ const FeedSettings = ({
   onConnect,
   onDisconnect,
 }: Props) => {
-  const buttonLabel = isConnected ? "Disconnect" : "Connect";
+  const buttonLabel = isConnected ? disconnectLabel : connectLabel;
   const onClick = isConnected ? onDisconnect : onConnect;
   const image = isConnected ? imageConnected : imageDisconnected;
 

--- a/packages/client-mobile/src/components/FeedSettings/index.tsx
+++ b/packages/client-mobile/src/components/FeedSettings/index.tsx
@@ -30,7 +30,7 @@ const FeedSettings = ({
   return (
     <View style={styles.wrapper}>
       <View style={styles.content}>
-        <View>{image}</View>
+        <View style={styles.image}>{image}</View>
         <View>
           <Text style={styles.title}>{title}</Text>
         </View>

--- a/packages/client-mobile/src/components/FeedSettings/styles.ts
+++ b/packages/client-mobile/src/components/FeedSettings/styles.ts
@@ -11,6 +11,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     padding: 20,
   },
+  image: {
+    width: 50,
+  },
   title: {
     fontSize: 18,
     fontWeight: "bold",

--- a/packages/client-mobile/src/modules/geolocation/logic/index.ts
+++ b/packages/client-mobile/src/modules/geolocation/logic/index.ts
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Geolocation from "@react-native-community/geolocation";
+import { Platform, PermissionsAndroid, Alert } from "react-native";
+import { usePersistedState } from "@modules/persisted-state/logic";
+import { promptAllowAccess } from "@modules/alert/logic";
 import { Coords } from "../types";
-import { Platform, PermissionsAndroid } from "react-native";
 
 type GeolocationError =
   | "PERMISSION_DENIED"
@@ -16,9 +18,16 @@ const errors: Record<number, GeolocationError> = {
   4: "ACTIVITY_NULL",
 };
 
-const requestPermission = async () => {
-  if (Platform.OS !== "android") return true;
+const checkIsPermittedIOS = async () => {
+  return new Promise<boolean>((resolve) => {
+    Geolocation.getCurrentPosition(
+      () => resolve(true),
+      () => resolve(false),
+    );
+  });
+};
 
+const checkIsPermittedAndroid = async () => {
   try {
     const granted = await PermissionsAndroid.request(
       PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
@@ -28,7 +37,7 @@ const requestPermission = async () => {
         buttonNeutral: "Ask Me Later",
         buttonNegative: "Cancel",
         buttonPositive: "Allow",
-      }
+      },
     );
 
     return granted === PermissionsAndroid.RESULTS.GRANTED;
@@ -37,35 +46,84 @@ const requestPermission = async () => {
   }
 };
 
-export const useGeolocation = (initialCoords: Coords) => {
-  const [coords, setCoords] = useState(initialCoords);
-  const [error, setError] = useState<GeolocationError | undefined>(undefined);
+const checkIsPermitted = async () => {
+  try {
+    if (Platform.OS === "ios") {
+      return await checkIsPermittedIOS();
+    } else {
+      return await checkIsPermittedAndroid();
+    }
+  } catch {
+    return false;
+  }
+};
 
-  useEffect(() => {
-    const getPosition = async () => {
-      const permissionGranted = await requestPermission();
+export const useGeolocation = () => {
+  const [coords, setCoords] = usePersistedState<Coords | undefined>(
+    "coords",
+    undefined,
+  );
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isConnected, setIsConnected] = usePersistedState(
+    "isGeolocationConnected",
+    false,
+  );
 
-      if (!permissionGranted) {
-        setError("PERMISSION_DENIED");
-        return;
-      }
+  const checkPermissionAndConnect = useCallback(async () => {
+    setIsConnecting(true);
+    const isPermitted = await checkIsPermitted();
+    setIsConnected(isPermitted);
+    setIsConnecting(false);
 
-      Geolocation.getCurrentPosition(
-        (info) => {
-          setCoords(info.coords);
-        },
-        ({ code }) => {
-          const err = errors[code] ?? "PERMISSION_DENIED";
-          setError(err);
-        }
-      );
-    };
-
-    getPosition();
+    return isPermitted;
   }, []);
+
+  // User may have connected previously but then, via the app settings in the
+  // OS, denied permissions. We should sync that setting here too.
+  useEffect(() => {
+    if (!isConnected) return;
+
+    checkPermissionAndConnect();
+  }, [checkPermissionAndConnect]);
+
+  const getPosition = useCallback(async () => {
+    Geolocation.getCurrentPosition(
+      (info) => {
+        setCoords(info.coords);
+      },
+      ({ code }) => {
+        const err = errors[code] ?? "PERMISSION_DENIED";
+
+        if (err === "PERMISSION_DENIED") {
+          promptAllowAccess("Please allow access to your location.");
+        } else {
+          Alert.alert("Could not get current location.");
+        }
+      },
+    );
+  }, []);
+
+  const connect = async () => {
+    const isPermitted = await checkPermissionAndConnect();
+
+    if (isPermitted) {
+      await getPosition();
+    } else {
+      promptAllowAccess("Please allow access to your location.");
+    }
+  };
+
+  const disconnect = () => {
+    setCoords(undefined);
+    setIsConnected(false);
+  };
 
   return {
     coords,
-    error,
+    isConnecting,
+    isConnected,
+    connect,
+    disconnect,
+    getPosition,
   };
 };

--- a/packages/client-mobile/src/modules/map/ui/Map/index.tsx
+++ b/packages/client-mobile/src/modules/map/ui/Map/index.tsx
@@ -4,10 +4,11 @@ import { useGeolocation } from "@modules/geolocation/logic";
 
 import styles from "./styles";
 
-// Melbourne, Victoria
+// TODO: cycle through different world locations
+// Centre of Australia
 const defaultCoords = {
-  latitude: -37.8136,
-  longitude: 144.9631,
+  latitude: -25.898716,
+  longitude: 133.843298,
 };
 
 export const Map = () => {
@@ -24,8 +25,8 @@ export const Map = () => {
       : {
           latitude: defaultCoords.latitude,
           longitude: defaultCoords.longitude,
-          latitudeDelta: 0.1,
-          longitudeDelta: 0.1,
+          latitudeDelta: 50,
+          longitudeDelta: 50,
         };
 
   useEffect(() => {

--- a/packages/client-mobile/src/modules/map/ui/Map/index.tsx
+++ b/packages/client-mobile/src/modules/map/ui/Map/index.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect } from "react";
 import MapView from "react-native-maps";
-import { Alert } from "react-native";
 import { useGeolocation } from "@modules/geolocation/logic";
 
 import styles from "./styles";
-import { promptAllowAccess } from "@modules/alert/logic";
 
 // Melbourne, Victoria
 const defaultCoords = {
@@ -13,25 +11,28 @@ const defaultCoords = {
 };
 
 export const Map = () => {
-  const { coords, error } = useGeolocation(defaultCoords);
+  const { coords, isConnected, getPosition } = useGeolocation();
 
-  const region = {
-    latitude: coords.latitude,
-    longitude: coords.longitude,
-    latitudeDelta: 0.1,
-    longitudeDelta: 0.1,
-  };
+  const region =
+    isConnected && coords
+      ? {
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+          latitudeDelta: 0.1,
+          longitudeDelta: 0.1,
+        }
+      : {
+          latitude: defaultCoords.latitude,
+          longitude: defaultCoords.longitude,
+          latitudeDelta: 0.1,
+          longitudeDelta: 0.1,
+        };
 
   useEffect(() => {
-    if (error === undefined) return;
-
-    if (error === "PERMISSION_DENIED") {
-      promptAllowAccess("Please allow access to your location.");
-      return;
+    if (isConnected) {
+      getPosition();
     }
-
-    Alert.alert("Could not get current location.");
-  }, [error]);
+  }, [isConnected, getPosition]);
 
   return <MapView style={styles.wrapper} region={region} showsUserLocation />;
 };

--- a/packages/client-mobile/src/modules/map/ui/Map/index.tsx
+++ b/packages/client-mobile/src/modules/map/ui/Map/index.tsx
@@ -34,5 +34,11 @@ export const Map = () => {
     }
   }, [isConnected, getPosition]);
 
-  return <MapView style={styles.wrapper} region={region} showsUserLocation />;
+  return (
+    <MapView
+      style={styles.wrapper}
+      region={region}
+      showsUserLocation={isConnected}
+    />
+  );
 };

--- a/packages/client-mobile/src/modules/map/ui/Map/index.tsx
+++ b/packages/client-mobile/src/modules/map/ui/Map/index.tsx
@@ -4,6 +4,7 @@ import { Alert } from "react-native";
 import { useGeolocation } from "@modules/geolocation/logic";
 
 import styles from "./styles";
+import { promptAllowAccess } from "@modules/alert/logic";
 
 // Melbourne, Victoria
 const defaultCoords = {
@@ -24,12 +25,12 @@ export const Map = () => {
   useEffect(() => {
     if (error === undefined) return;
 
-    const message =
-      error === "PERMISSION_DENIED"
-        ? "For the best experience, please allow access to your location."
-        : "Could not get current location.";
+    if (error === "PERMISSION_DENIED") {
+      promptAllowAccess("Please allow access to your location.");
+      return;
+    }
 
-    Alert.alert(message);
+    Alert.alert("Could not get current location.");
   }, [error]);
 
   return <MapView style={styles.wrapper} region={region} showsUserLocation />;

--- a/packages/client-mobile/src/screens/Settings/index.tsx
+++ b/packages/client-mobile/src/screens/Settings/index.tsx
@@ -9,6 +9,7 @@ import { ScreenProps } from "../types";
 import ScreenTemplate from "../ScreenTemplate";
 import FeedSettings from "@components/FeedSettings";
 import { useMedia } from "@modules/media/logic";
+import { useGeolocation } from "@modules/geolocation/logic";
 
 const photosFeedSettings = {
   title: "Photos",
@@ -36,6 +37,7 @@ const locationSettings = {
 
 const SettingsScreen = (_: ScreenProps<"settings">) => {
   const media = useMedia();
+  const geolocation = useGeolocation();
 
   const feeds = [
     {
@@ -61,10 +63,10 @@ const SettingsScreen = (_: ScreenProps<"settings">) => {
           <View style={styles.feedSettingsWrapper}>
             <FeedSettings
               {...locationSettings}
-              isConnected={false}
-              isConnecting={false}
-              onConnect={() => {}}
-              onDisconnect={() => {}}
+              isConnected={geolocation.isConnected}
+              isConnecting={geolocation.isConnecting}
+              onConnect={geolocation.connect}
+              onDisconnect={geolocation.disconnect}
             />
           </View>
         </View>

--- a/packages/client-mobile/src/screens/Settings/index.tsx
+++ b/packages/client-mobile/src/screens/Settings/index.tsx
@@ -24,6 +24,8 @@ const photosFeedSettings = {
 const locationSettings = {
   title: "Current location",
   url: undefined,
+  connectLabel: "Enable",
+  disconnectLabel: "Disable",
   imageConnected: (
     <Icon name="my-location" size={35} color={colorPalette.mediumAquamarine} />
   ),

--- a/packages/client-mobile/src/screens/Settings/index.tsx
+++ b/packages/client-mobile/src/screens/Settings/index.tsx
@@ -14,10 +14,21 @@ const photosFeedSettings = {
   title: "Photos",
   url: undefined,
   imageConnected: (
-    <Icon name="image" size={60} color={colorPalette.mediumAquamarine} />
+    <Icon name="image" size={35} color={colorPalette.mediumAquamarine} />
   ),
   imageDisconnected: (
-    <Icon name="image" size={60} color={colorPalette.matterhorn} />
+    <Icon name="image" size={35} color={colorPalette.matterhorn} />
+  ),
+};
+
+const locationSettings = {
+  title: "Current location",
+  url: undefined,
+  imageConnected: (
+    <Icon name="my-location" size={35} color={colorPalette.mediumAquamarine} />
+  ),
+  imageDisconnected: (
+    <Icon name="my-location" size={35} color={colorPalette.matterhorn} />
   ),
 };
 
@@ -43,6 +54,16 @@ const SettingsScreen = (_: ScreenProps<"settings">) => {
             {feeds.map((props) => (
               <FeedSettings key={props.title} {...props} />
             ))}
+          </View>
+          <Text style={styles.title}>Map</Text>
+          <View style={styles.feedSettingsWrapper}>
+            <FeedSettings
+              {...locationSettings}
+              isConnected={false}
+              isConnecting={false}
+              onConnect={() => {}}
+              onDisconnect={() => {}}
+            />
           </View>
         </View>
       </View>

--- a/packages/client-mobile/src/screens/Settings/styles.ts
+++ b/packages/client-mobile/src/screens/Settings/styles.ts
@@ -4,7 +4,6 @@ const styles = StyleSheet.create({
   wrapper: {
     flex: 1,
     alignItems: "center",
-    paddingVertical: 40,
     paddingHorizontal: 20,
   },
   content: {
@@ -12,11 +11,12 @@ const styles = StyleSheet.create({
     maxWidth: 600,
   },
   title: {
+    marginTop: 40,
     fontSize: 28,
     fontWeight: "500",
   },
   feedSettingsWrapper: {
-    marginTop: 40,
+    marginTop: 20,
   },
 });
 


### PR DESCRIPTION
# Background
- Currently geolocation is requested immediately on Map first render
- This can be quite confronting. Better to let the user opt in via the Settings page.

# Changes
- Added a settings entry for it with Enable/Disable buttons
- It will only be fetched if it is enable
- Refactored the `useGeolocation` hook to be similar to `useMedia`. Same interface.

<img width="200" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/6a0ac160-42dd-4a24-b88d-1a6982cb55c6">
<img width="200" alt="image" src="https://github.com/mzogheib/quoll/assets/10183584/5d8e5ad2-7be7-4549-bf00-37aa0448e21a">
