### PR TITLE
fix(client-web): fix path aliases

### DIFF
--- a/packages/client-web/.eslintrc.js
+++ b/packages/client-web/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
         patterns: [
           {
             group: ["*/*/modules/*/*"],
-            message: "Import from @modules/ instead.",
+            message: "Import from modules/ instead.",
           },
         ],
       },

--- a/packages/client-web/src/App/index.tsx
+++ b/packages/client-web/src/App/index.tsx
@@ -2,11 +2,11 @@ import { useState, useEffect } from "react";
 import styled, { css } from "styled-components";
 import { Route, Switch, useHistory, useLocation } from "react-router-dom";
 
-import userService from "@modules/user/service";
-import { useUserViewModel } from "@modules/user/view-model";
-import { useFeedsViewModel } from "@modules/feeds/view-model";
-import Header from "@components/Header";
-import SideBar from "@components/SideBar";
+import userService from "modules/user/service";
+import { useUserViewModel } from "modules/user/view-model";
+import { useFeedsViewModel } from "modules/feeds/view-model";
+import Header from "components/Header";
+import SideBar from "components/SideBar";
 import routes from "../routes";
 import WelcomeModal from "./WelcomeModal";
 

--- a/packages/client-web/src/components/FeedLogo/index.tsx
+++ b/packages/client-web/src/components/FeedLogo/index.tsx
@@ -1,4 +1,4 @@
-import { FeedName } from "@modules/feeds/types";
+import { FeedName } from "modules/feeds/types";
 
 const logoMap = {
   [FeedName.Toshl]: {

--- a/packages/client-web/src/components/FeedSettings/index.tsx
+++ b/packages/client-web/src/components/FeedSettings/index.tsx
@@ -1,9 +1,9 @@
 import styled, { css } from "styled-components";
 import { ButtonPlain, HorizontalLoader } from "@quoll/ui-components";
 
-import { FeedName } from "@modules/feeds/types";
-import { FeedState } from "@modules/feeds/model/store";
-import FeedLogo from "@components/FeedLogo";
+import { FeedName } from "modules/feeds/types";
+import { FeedState } from "modules/feeds/model/store";
+import FeedLogo from "components/FeedLogo";
 
 const Wrapper = styled.div(
   ({ theme: { colors } }) => css`

--- a/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
+++ b/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import moment from "moment";
 
-import FeedLogo from "@components/FeedLogo";
+import FeedLogo from "components/FeedLogo";
 import { getEntryImage } from "../../service";
 import { Entry } from "../../types";
 

--- a/packages/client-web/src/routes/Home/index.tsx
+++ b/packages/client-web/src/routes/Home/index.tsx
@@ -3,11 +3,11 @@ import styled, { css } from "styled-components";
 import moment from "moment";
 import { HorizontalLoader } from "@quoll/ui-components";
 
-import { useTimelineViewModel } from "@modules/timeline/view-model";
-import { useDateViewModelModel } from "@modules/date/view-model";
-import DatePicker from "@modules/date/views/DatePicker";
-import Timeline from "@modules/timeline/views/Timeline";
-import Map from "@components/Map";
+import { useTimelineViewModel } from "modules/timeline/view-model";
+import { useDateViewModelModel } from "modules/date/view-model";
+import DatePicker from "modules/date/views/DatePicker";
+import Timeline from "modules/timeline/views/Timeline";
+import Map from "components/Map";
 import { makePolylineConfigs, makeInfoWindowOptions } from "./mapUtils";
 
 const Wrapper = styled.div(

--- a/packages/client-web/src/routes/Home/mapUtils.ts
+++ b/packages/client-web/src/routes/Home/mapUtils.ts
@@ -1,8 +1,8 @@
 import moment from "moment";
 
-import { Entry } from "@modules/timeline/types";
-import { PolylineConfig } from "@components/Map/Component";
-import { decodePath } from "@components/Map/utils";
+import { Entry } from "modules/timeline/types";
+import { PolylineConfig } from "components/Map/Component";
+import { decodePath } from "components/Map/utils";
 
 const mapElementColors = {
   default: "#eb4434",

--- a/packages/client-web/src/routes/Settings/index.tsx
+++ b/packages/client-web/src/routes/Settings/index.tsx
@@ -2,10 +2,10 @@ import { useState, useEffect } from "react";
 import styled from "styled-components";
 import { useHistory, useLocation } from "react-router-dom";
 
-import { FeedName } from "@modules/feeds/types";
-import { useFeedsViewModel } from "@modules/feeds/view-model";
-import FeedSettings from "@components/FeedSettings";
-import AlertModal from "@components/modals/AlertModal";
+import { FeedName } from "modules/feeds/types";
+import { useFeedsViewModel } from "modules/feeds/view-model";
+import FeedSettings from "components/FeedSettings";
+import AlertModal from "components/modals/AlertModal";
 import { requestAuth } from "../../services/oauth";
 import { SettingsLocationState } from "../types";
 

--- a/packages/client-web/src/store/index.ts
+++ b/packages/client-web/src/store/index.ts
@@ -2,10 +2,10 @@ import { createStore, applyMiddleware, combineReducers } from "redux";
 import thunkMiddleware from "redux-thunk";
 import { composeWithDevTools } from "redux-devtools-extension";
 
-import user from "@modules/user/model/store";
-import date from "@modules/date/model/store";
-import feeds from "@modules/feeds/model/store";
-import timeline from "@modules/timeline/model/store";
+import user from "modules/user/model/store";
+import date from "modules/date/model/store";
+import feeds from "modules/feeds/model/store";
+import timeline from "modules/timeline/model/store";
 
 const reducer = combineReducers({
   user,

--- a/packages/client-web/tsconfig.json
+++ b/packages/client-web/tsconfig.json
@@ -15,10 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "paths": {
-      "@components/*": ["./src/components/*"],
-      "@modules/*": ["./src/modules/*"]
-    }
+    "baseUrl": "./src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
- CRA doesn't appear to support path aliases
- Specifying the `baseUrl` property simulates aliases so long as the folders are well structured, which they are