### PR TITLE
feat(client-mobile): implement the user service

### DIFF
--- a/packages/client-mobile/env.d.ts
+++ b/packages/client-mobile/env.d.ts
@@ -1,3 +1,3 @@
 declare module "@env" {
-  export const TEST_VAR: string;
+  export const API_URL: string;
 }

--- a/packages/client-mobile/src/modules/user/model/index.ts
+++ b/packages/client-mobile/src/modules/user/model/index.ts
@@ -43,7 +43,7 @@ export const useUserModel = () => {
   const signup = useCallback(async () => {
     setProperty("isAuthenticating", true);
     const user = await userService.signup();
-    setUserId(user.id);
+    setUserId(user._id);
     setProperty("user", user);
     setProperty("isAuthenticating", false);
   }, [setProperty]);

--- a/packages/client-mobile/src/modules/user/service/index.ts
+++ b/packages/client-mobile/src/modules/user/service/index.ts
@@ -1,7 +1,7 @@
 import { User } from "../types";
 
 export const login = async (userId: string): Promise<User> => ({
-  id: userId,
+  _id: userId,
 });
 
-export const signup = async (): Promise<User> => ({ id: "123-abc" });
+export const signup = async (): Promise<User> => ({ _id: "123-abc" });

--- a/packages/client-mobile/src/modules/user/service/index.ts
+++ b/packages/client-mobile/src/modules/user/service/index.ts
@@ -1,7 +1,10 @@
+import api from "@utils/api";
 import { User } from "../types";
 
-export const login = async (userId: string): Promise<User> => ({
-  _id: userId,
-});
+export const login = async (userId: string) =>
+  await api.post<User>({
+    endpoint: "login",
+    payload: { userId },
+  });
 
-export const signup = async (): Promise<User> => ({ _id: "123-abc" });
+export const signup = async () => await api.post<User>({ endpoint: "signup" });

--- a/packages/client-mobile/src/modules/user/types.ts
+++ b/packages/client-mobile/src/modules/user/types.ts
@@ -1,3 +1,3 @@
 export type User = {
-  id: string;
+  _id: string;
 };

--- a/packages/client-mobile/src/utils/api/index.ts
+++ b/packages/client-mobile/src/utils/api/index.ts
@@ -1,0 +1,69 @@
+import axios, { AxiosRequestConfig } from "axios";
+import { API_URL } from "@env";
+
+// TODO: come up with a better way than this. Redux or a cookie.
+let authHeader: AxiosRequestConfig["headers"];
+
+const authenticate = (userId: string) => {
+  authHeader = { Authorization: `Basic ${userId}:` };
+};
+
+interface RequestParams {
+  endpoint: string;
+  params?: AxiosRequestConfig["params"];
+  payload?: AxiosRequestConfig["data"];
+}
+
+const makeUrl = ({ endpoint, params }: RequestParams) => {
+  const baseUrl = `${API_URL}/${endpoint}`;
+
+  const search = new URLSearchParams(params);
+  const searchString = search.toString();
+
+  if (searchString) return `${baseUrl}?${searchString}`;
+
+  return baseUrl;
+};
+
+const get = async <ResponseData>({ endpoint, params }: RequestParams) => {
+  const config = { headers: authHeader };
+
+  const url = makeUrl({ endpoint, params });
+
+  const response = await axios.get<ResponseData>(url, config);
+
+  return response.data;
+};
+
+const post = async <ResponseData>({
+  endpoint,
+  payload,
+  params,
+}: RequestParams) => {
+  const config = { headers: authHeader };
+
+  const url = makeUrl({ endpoint, params });
+
+  const response = await axios.post<ResponseData>(url, payload, config);
+
+  return response.data;
+};
+
+const deleteReq = async <ResponseData>({ endpoint, params }: RequestParams) => {
+  const config = { headers: authHeader };
+
+  const url = makeUrl({ endpoint, params });
+
+  const response = await axios.delete<ResponseData>(url, config);
+
+  return response.data;
+};
+
+const apiService = {
+  authenticate,
+  get,
+  post,
+  delete: deleteReq,
+};
+
+export default apiService;

--- a/packages/client-mobile/src/utils/api/index.ts
+++ b/packages/client-mobile/src/utils/api/index.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { API_URL } from "@env";
 
-// TODO: come up with a better way than this. Redux or a cookie.
+// TODO: come up with a better way than this.
 let authHeader: AxiosRequestConfig["headers"];
 
 const authenticate = (userId: string) => {


### PR DESCRIPTION
* Copies the `api` and `user` service implementation from `client-web`
* Uses the locally running `api` to login and sign up
* Need to follow up with better error handling
* Most of it can also be moved to `lib` or `client-lib`