### PR TITLE
refactor: move services to `client-lib`

### DIFF
--- a/packages/client-lib/package.json
+++ b/packages/client-lib/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@quoll/lib": "^0.3.0",
+    "moment": "^2.30.1",
     "react-redux": "^7.2.1",
     "redux": "^4.0.5"
   },

--- a/packages/client-lib/src/modules/feeds/service/index.ts
+++ b/packages/client-lib/src/modules/feeds/service/index.ts
@@ -1,7 +1,40 @@
 import { FeedName } from "@quoll/lib";
+import { AuthenticatedApiService } from "../../../utils";
 
-export type FeedsService = {
-  getOauthUrl: (feedName: FeedName) => Promise<string>;
-  authenticate: (feed: FeedName, payload: { code: string }) => Promise<null>;
-  deauthorize: (feed: FeedName) => Promise<string | undefined>;
+type AuthenticatePayload = {
+  code: string;
 };
+
+const endpoint = "/feed-auth";
+
+export class FeedsService extends AuthenticatedApiService {
+  async getOauthUrl(feed: FeedName) {
+    return this.request<string>({
+      method: "GET",
+      endpoint,
+      params: { feed },
+    });
+  }
+
+  async authenticate(feed: FeedName, payload: AuthenticatePayload) {
+    return this.request<null>({
+      method: "POST",
+      endpoint,
+      payload,
+      params: { feed },
+    });
+  }
+
+  async deauthorize(feed: FeedName) {
+    return this.request<null>({
+      method: "DELETE",
+      endpoint,
+      params: { feed },
+    }).then(() => {
+      // TODO: this should come from the BE
+      if (feed === "moves") {
+        return "Remember to revoke access in the Moves app.";
+      }
+    });
+  }
+}

--- a/packages/client-lib/src/modules/timeline/service/index.ts
+++ b/packages/client-lib/src/modules/timeline/service/index.ts
@@ -1,5 +1,56 @@
-import { ISO8601Date, TimelineEntry } from "@quoll/lib";
+import moment from "moment";
+import { ISO8601Date, TimelineEntry, TimelineEntryType } from "@quoll/lib";
 
-export type TimelineService = {
-  get: (date: ISO8601Date) => Promise<TimelineEntry[]>;
+import { AuthenticatedApiService } from "../../../utils";
+
+type EntryConfig = {
+  label: string;
+  image: string;
 };
+
+const EntryConfigMap: Record<TimelineEntryType, EntryConfig> = {
+  bike: { label: "Bike", image: "🚲" },
+  bus: { label: "Bus", image: "🚌" },
+  car: { label: "Car", image: "🚗" },
+  "e-bike": { label: "E-Bike", image: "🚲⚡️" },
+  expense: { label: "Expense", image: "💸" },
+  ferry: { label: "Ferry", image: "🛳️" },
+  flight: { label: "Flight", image: "✈️" },
+  hike: { label: "Hike", image: "🥾" },
+  home: { label: "Home", image: "🏠" },
+  income: { label: "Income", image: "💰" },
+  motorcycle: { label: "Motorcycle", image: "🏍️" },
+  photo: { label: "Photo", image: "📸" },
+  place: { label: "Place", image: "🏬" },
+  run: { label: "Run", image: "🏃‍♂️" },
+  train: { label: "Train", image: "🚆" },
+  tram: { label: "Tram", image: "🚊" },
+  transport: { label: "Transport", image: "⏩" },
+  unknown: { label: "Unknown", image: "🤷" },
+  velomobile: { label: "Velomobile", image: "🚲🛡️" },
+  video: { label: "Video", image: "🎥" },
+  walk: { label: "Walk", image: "🚶‍♂️" },
+  work: { label: "Work", image: "🏭" },
+  yoga: { label: "Yoga", image: "🧘‍♂️" },
+};
+
+export const getTimelineEntryImage = (entry: TimelineEntry) =>
+  EntryConfigMap[entry.type] ? EntryConfigMap[entry.type].image : "🤠";
+
+// TODO move this to client-lib
+// Convert to a class
+// Has an array of sources to fetch from
+// Consumer can push to the array
+
+export class TimelineService extends AuthenticatedApiService {
+  async get(date: ISO8601Date) {
+    return this.request<TimelineEntry[]>({
+      method: "GET",
+      endpoint: "/timeline",
+      params: {
+        from: moment(date).startOf("day").toISOString(),
+        to: moment(date).endOf("day").toISOString(),
+      },
+    });
+  }
+}

--- a/packages/client-lib/src/modules/timeline/service/index.ts
+++ b/packages/client-lib/src/modules/timeline/service/index.ts
@@ -34,11 +34,11 @@ const EntryConfigMap: Record<TimelineEntryType, EntryConfig> = {
   yoga: { label: "Yoga", image: "🧘‍♂️" },
 };
 
+// TODO should this be somewhere else?
 export const getTimelineEntryImage = (entry: TimelineEntry) =>
   EntryConfigMap[entry.type] ? EntryConfigMap[entry.type].image : "🤠";
 
-// TODO move this to client-lib
-// Convert to a class
+// TODO
 // Has an array of sources to fetch from
 // Consumer can push to the array
 

--- a/packages/client-lib/src/modules/user/service/index.ts
+++ b/packages/client-lib/src/modules/user/service/index.ts
@@ -1,6 +1,19 @@
 import { User } from "@quoll/lib";
+import { ApiService } from "../../../utils";
 
-export type UserService = {
-  login: (userId: string) => Promise<User>;
-  signup: () => Promise<User>;
-};
+export class UserService extends ApiService {
+  async login(userId: string) {
+    return this.request<User>({
+      method: "POST",
+      endpoint: "/login",
+      payload: { userId },
+    });
+  }
+
+  async signup() {
+    return await this.request<User>({
+      method: "POST",
+      endpoint: "/signup",
+    });
+  }
+}

--- a/packages/client-lib/src/utils/api/index.ts
+++ b/packages/client-lib/src/utils/api/index.ts
@@ -5,7 +5,7 @@ type RequestParams = {
   payload?: object;
 };
 
-export class ApiService {
+export abstract class ApiService {
   private baseUrl: string;
 
   constructor(baseUrl: string) {
@@ -33,7 +33,7 @@ export class ApiService {
    * const data = apiService.request<null>({ ... })
    * ```
    */
-  async request<Response>({
+  protected async request<Response>({
     method,
     endpoint,
     params,

--- a/packages/client-lib/src/utils/api/index.ts
+++ b/packages/client-lib/src/utils/api/index.ts
@@ -7,7 +7,6 @@ type RequestParams = {
 
 export class ApiService {
   private baseUrl: string;
-  private authHeader?: { Authorization: string };
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
@@ -46,7 +45,6 @@ export class ApiService {
       body: JSON.stringify(payload),
       headers: {
         "Content-Type": "application/json",
-        ...this.authHeader,
       },
     };
 
@@ -70,9 +68,5 @@ export class ApiService {
     };
 
     throw new Error(JSON.stringify(error));
-  }
-
-  authenticate(userId: string): void {
-    this.authHeader = { Authorization: `Basic ${userId}:` };
   }
 }

--- a/packages/client-lib/src/utils/authenticated-api/index.ts
+++ b/packages/client-lib/src/utils/authenticated-api/index.ts
@@ -41,7 +41,7 @@ export abstract class AuthenticatedApiService {
    * @example
    *
    * ```
-   * const data = apiService.request<null>({ ... })
+   * const data = authenticatedApiService.request<null>({ ... })
    * ```
    */
   protected async request<Response>({

--- a/packages/client-lib/src/utils/authenticated-api/index.ts
+++ b/packages/client-lib/src/utils/authenticated-api/index.ts
@@ -1,0 +1,81 @@
+type RequestParams = {
+  method: "GET" | "PUT" | "POST" | "DELETE";
+  endpoint: string;
+  params?: Record<string, string>;
+  payload?: object;
+};
+
+export abstract class AuthenticatedApiService {
+  private baseUrl: string;
+  private getAccessToken: () => Promise<string>;
+
+  constructor(getAccessToken: () => Promise<string>, baseUrl: string) {
+    this.getAccessToken = getAccessToken;
+    this.baseUrl = baseUrl;
+  }
+
+  private makeUrl(endpoint: string, params?: Record<string, string>) {
+    const baseUrl = `${this.baseUrl}${endpoint}`;
+
+    const search = new URLSearchParams(params);
+    const searchString = search.toString();
+
+    if (searchString) return `${baseUrl}?${searchString}`;
+
+    return baseUrl;
+  }
+
+  private async makeHeaders() {
+    const accessToken = await this.getAccessToken();
+
+    return {
+      "Content-Type": "application/json",
+      authorization: `Bearer ${accessToken}`,
+    };
+  }
+
+  /**
+   * If the endpoint will not return any content then `Response` should be
+   * `null`.
+   *
+   * @example
+   *
+   * ```
+   * const data = apiService.request<null>({ ... })
+   * ```
+   */
+  protected async request<Response>({
+    method,
+    endpoint,
+    params,
+    payload,
+  }: RequestParams) {
+    const url = this.makeUrl(endpoint, params);
+    const init = {
+      method,
+      body: JSON.stringify(payload),
+      headers: await this.makeHeaders(),
+    };
+
+    const response = await fetch(url, init);
+
+    const contentHeader = response.headers.get("Content-Length");
+    const hasContent = contentHeader && contentHeader !== "0";
+
+    // The caller should know whether or not the response has content.
+    // If it does, the `Response` type will be set as non-null.
+    // If it does not, the `Response` type will be set as `null`.
+    // Hence the value of responseJson will always match the caller's intention.
+    const responseJson: Response = hasContent ? await response.json() : null;
+
+    if (response.ok) return responseJson;
+
+    const error = {
+      status: response.status,
+      statusText: response.statusText,
+      body: responseJson,
+    };
+
+    throw new Error(JSON.stringify(error));
+  }
+}

--- a/packages/client-lib/src/utils/index.ts
+++ b/packages/client-lib/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./api";
+export * from "./authenticated-api";

--- a/packages/client-mobile/src/modules/timeline/service/index.ts
+++ b/packages/client-mobile/src/modules/timeline/service/index.ts
@@ -1,14 +1,7 @@
 import { TimelineService } from "@quoll/client-lib";
-import { ISO8601Date } from "@quoll/lib";
+import { getAccessToken } from "@utils/session";
+import { API_URL } from "@env";
 
-const get = async (date: ISO8601Date) => {
-  console.log("getting timeline for", date);
-
-  return [];
-};
-
-const timelineService: TimelineService = {
-  get,
-};
+const timelineService = new TimelineService(getAccessToken, API_URL);
 
 export default timelineService;

--- a/packages/client-mobile/src/modules/user/model/index.ts
+++ b/packages/client-mobile/src/modules/user/model/index.ts
@@ -4,7 +4,6 @@ import { useUserModel as _useUserModel } from "@quoll/client-lib";
 
 import { makeStorage } from "@utils/storage";
 import { makeStore } from "@utils/store";
-import { apiService } from "@utils/api";
 import * as userService from "../service";
 
 export const storage = makeStorage<{ id: string }>("user");
@@ -26,12 +25,10 @@ export const useUserModel = () => {
 
   const login = useCallback(async (userId: string) => {
     const user = await model.login(userId);
-    apiService.authenticate(user._id);
   }, []);
 
   const signup = useCallback(async () => {
     const user = await model.signup();
-    apiService.authenticate(user._id);
   }, []);
 
   return {

--- a/packages/client-mobile/src/modules/user/model/index.ts
+++ b/packages/client-mobile/src/modules/user/model/index.ts
@@ -4,7 +4,7 @@ import { useUserModel as _useUserModel } from "@quoll/client-lib";
 
 import { makeStorage } from "@utils/storage";
 import { makeStore } from "@utils/store";
-import * as userService from "../service";
+import { userService } from "../service";
 
 export const storage = makeStorage<{ id: string }>("user");
 

--- a/packages/client-mobile/src/modules/user/model/index.ts
+++ b/packages/client-mobile/src/modules/user/model/index.ts
@@ -7,7 +7,7 @@ import { makeStore } from "@utils/store";
 import { apiService } from "@utils/api";
 import * as userService from "../service";
 
-const storage = makeStorage<{ id: string }>("user");
+export const storage = makeStorage<{ id: string }>("user");
 
 type State = {
   isAuthenticating: boolean;

--- a/packages/client-mobile/src/modules/user/service/index.ts
+++ b/packages/client-mobile/src/modules/user/service/index.ts
@@ -1,15 +1,4 @@
-import { User } from "@quoll/lib";
-import { apiService } from "@utils/api";
+import { UserService } from "@quoll/client-lib";
+import { API_URL } from "@env";
 
-export const login = async (userId: string) =>
-  await apiService.request<User>({
-    method: "POST",
-    endpoint: "/login",
-    payload: { userId },
-  });
-
-export const signup = async () =>
-  await apiService.request<User>({
-    method: "POST",
-    endpoint: "/signup",
-  });
+export const userService = new UserService(API_URL);

--- a/packages/client-mobile/src/utils/api/index.ts
+++ b/packages/client-mobile/src/utils/api/index.ts
@@ -1,4 +1,0 @@
-import { API_URL } from "@env";
-import { ApiService } from "@quoll/client-lib";
-
-export const apiService = new ApiService(API_URL);

--- a/packages/client-mobile/src/utils/session/index.ts
+++ b/packages/client-mobile/src/utils/session/index.ts
@@ -1,0 +1,10 @@
+import { storage as userStorage } from "@modules/user/model";
+
+// A hacky solution for now
+export const getAccessToken = async () => {
+  const userId = userStorage.getData()?.id;
+
+  if (!userId) throw new Error("Unauthenticated");
+
+  return userId;
+};

--- a/packages/client-web/src/modules/feeds/service/index.ts
+++ b/packages/client-web/src/modules/feeds/service/index.ts
@@ -1,47 +1,8 @@
-import { AuthenticatedApiService, FeedsService } from "@quoll/client-lib";
-import { FeedName } from "@quoll/lib";
+import { FeedsService } from "@quoll/client-lib";
 
 import { getAccessToken } from "services/session";
 
-type AuthenticatePayload = {
-  code: string;
-};
-
-const endpoint = "/feed-auth";
-
-class _FeedsService extends AuthenticatedApiService implements FeedsService {
-  async getOauthUrl(feed: FeedName) {
-    return this.request<string>({
-      method: "GET",
-      endpoint,
-      params: { feed },
-    });
-  }
-
-  async authenticate(feed: FeedName, payload: AuthenticatePayload) {
-    return this.request<null>({
-      method: "POST",
-      endpoint,
-      payload,
-      params: { feed },
-    });
-  }
-
-  async deauthorize(feed: FeedName) {
-    return this.request<null>({
-      method: "DELETE",
-      endpoint,
-      params: { feed },
-    }).then(() => {
-      // TODO: this should come from the BE
-      if (feed === "moves") {
-        return "Remember to revoke access in the Moves app.";
-      }
-    });
-  }
-}
-
-const feedsService = new _FeedsService(
+const feedsService = new FeedsService(
   getAccessToken,
   `${process.env.REACT_APP_API_URL}`,
 );

--- a/packages/client-web/src/modules/timeline/service/index.ts
+++ b/packages/client-web/src/modules/timeline/service/index.ts
@@ -1,8 +1,8 @@
 import moment from "moment";
 import { ISO8601Date, TimelineEntry, TimelineEntryType } from "@quoll/lib";
-import { TimelineService } from "@quoll/client-lib";
+import { AuthenticatedApiService, TimelineService } from "@quoll/client-lib";
 
-import { apiService } from "services/api";
+import { getAccessToken } from "services/session";
 
 type EntryConfig = {
   label: string;
@@ -43,18 +43,25 @@ export const getEntryImage = (entry: TimelineEntry) =>
 // Has an array of sources to fetch from
 // Consumer can push to the array
 
-const get = (date: ISO8601Date) =>
-  apiService.request<TimelineEntry[]>({
-    method: "GET",
-    endpoint: "/timeline",
-    params: {
-      from: moment(date).startOf("day").toISOString(),
-      to: moment(date).endOf("day").toISOString(),
-    },
-  });
+class _TimelineService
+  extends AuthenticatedApiService
+  implements TimelineService
+{
+  async get(date: ISO8601Date) {
+    return this.request<TimelineEntry[]>({
+      method: "GET",
+      endpoint: "/timeline",
+      params: {
+        from: moment(date).startOf("day").toISOString(),
+        to: moment(date).endOf("day").toISOString(),
+      },
+    });
+  }
+}
 
-const timelineService: TimelineService = {
-  get,
-};
+const timelineService = new _TimelineService(
+  getAccessToken,
+  `${process.env.REACT_APP_API_URL}`,
+);
 
 export default timelineService;

--- a/packages/client-web/src/modules/timeline/service/index.ts
+++ b/packages/client-web/src/modules/timeline/service/index.ts
@@ -1,65 +1,8 @@
-import moment from "moment";
-import { ISO8601Date, TimelineEntry, TimelineEntryType } from "@quoll/lib";
-import { AuthenticatedApiService, TimelineService } from "@quoll/client-lib";
+import { TimelineService } from "@quoll/client-lib";
 
 import { getAccessToken } from "services/session";
 
-type EntryConfig = {
-  label: string;
-  image: string;
-};
-
-const EntryConfigMap: Record<TimelineEntryType, EntryConfig> = {
-  bike: { label: "Bike", image: "🚲" },
-  bus: { label: "Bus", image: "🚌" },
-  car: { label: "Car", image: "🚗" },
-  "e-bike": { label: "E-Bike", image: "🚲⚡️" },
-  expense: { label: "Expense", image: "💸" },
-  ferry: { label: "Ferry", image: "🛳️" },
-  flight: { label: "Flight", image: "✈️" },
-  hike: { label: "Hike", image: "🥾" },
-  home: { label: "Home", image: "🏠" },
-  income: { label: "Income", image: "💰" },
-  motorcycle: { label: "Motorcycle", image: "🏍️" },
-  photo: { label: "Photo", image: "📸" },
-  place: { label: "Place", image: "🏬" },
-  run: { label: "Run", image: "🏃‍♂️" },
-  train: { label: "Train", image: "🚆" },
-  tram: { label: "Tram", image: "🚊" },
-  transport: { label: "Transport", image: "⏩" },
-  unknown: { label: "Unknown", image: "🤷" },
-  velomobile: { label: "Velomobile", image: "🚲🛡️" },
-  video: { label: "Video", image: "🎥" },
-  walk: { label: "Walk", image: "🚶‍♂️" },
-  work: { label: "Work", image: "🏭" },
-  yoga: { label: "Yoga", image: "🧘‍♂️" },
-};
-
-export const getEntryImage = (entry: TimelineEntry) =>
-  EntryConfigMap[entry.type] ? EntryConfigMap[entry.type].image : "🤠";
-
-// TODO move this to client-lib
-// Convert to a class
-// Has an array of sources to fetch from
-// Consumer can push to the array
-
-class _TimelineService
-  extends AuthenticatedApiService
-  implements TimelineService
-{
-  async get(date: ISO8601Date) {
-    return this.request<TimelineEntry[]>({
-      method: "GET",
-      endpoint: "/timeline",
-      params: {
-        from: moment(date).startOf("day").toISOString(),
-        to: moment(date).endOf("day").toISOString(),
-      },
-    });
-  }
-}
-
-const timelineService = new _TimelineService(
+const timelineService = new TimelineService(
   getAccessToken,
   `${process.env.REACT_APP_API_URL}`,
 );

--- a/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
+++ b/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
@@ -1,9 +1,9 @@
 import styled, { css } from "styled-components";
 import moment from "moment";
 import { TimelineEntry as ITimelineEntry } from "@quoll/lib";
+import { getTimelineEntryImage } from "@quoll/client-lib";
 
 import FeedLogo from "components/FeedLogo";
-import { getEntryImage } from "../../service";
 
 const Wrapper = styled.div(
   ({ theme: { colors } }) => css`
@@ -60,7 +60,7 @@ interface Props {
 }
 
 const TimelineEntry = ({ entry, onClick }: Props) => {
-  const image = getEntryImage(entry);
+  const image = getTimelineEntryImage(entry);
 
   return (
     <Wrapper onClick={onClick}>

--- a/packages/client-web/src/modules/user/model/index.ts
+++ b/packages/client-web/src/modules/user/model/index.ts
@@ -10,7 +10,7 @@ import { makeStorage } from "services/storage";
 import userService from "../service";
 import { RootState } from "store";
 
-const storage = makeStorage<{ id: string }>("user");
+export const storage = makeStorage<{ id: string }>("user");
 
 const defaultState: UserState = {
   isAuthenticating: true,

--- a/packages/client-web/src/modules/user/model/index.ts
+++ b/packages/client-web/src/modules/user/model/index.ts
@@ -5,7 +5,6 @@ import {
   makeReduxStoreSlice,
 } from "@quoll/client-lib";
 
-import { apiService } from "services/api";
 import { makeStorage } from "services/storage";
 import userService from "../service";
 import { RootState } from "store";
@@ -28,7 +27,6 @@ export const useUserModel = () => {
   const login = useCallback(
     async (userId: string) => {
       const user = await model.login(userId);
-      apiService.authenticate(user._id);
 
       return user;
     },
@@ -36,8 +34,7 @@ export const useUserModel = () => {
   );
 
   const signup = useCallback(async () => {
-    const user = await model.signup();
-    apiService.authenticate(user._id);
+    await model.signup();
   }, [model]);
 
   return {

--- a/packages/client-web/src/modules/user/model/index.ts
+++ b/packages/client-web/src/modules/user/model/index.ts
@@ -6,7 +6,7 @@ import {
 } from "@quoll/client-lib";
 
 import { makeStorage } from "services/storage";
-import userService from "../service";
+import { userService } from "../service";
 import { RootState } from "store";
 
 export const storage = makeStorage<{ id: string }>("user");

--- a/packages/client-web/src/modules/user/service/index.ts
+++ b/packages/client-web/src/modules/user/service/index.ts
@@ -1,19 +1,3 @@
-import { User } from "@quoll/lib";
-import { apiService } from "services/api";
+import { UserService } from "@quoll/client-lib";
 
-const login = async (userId: string) =>
-  await apiService.request<User>({
-    method: "POST",
-    endpoint: "/login",
-    payload: { userId },
-  });
-
-const signup = async () =>
-  await apiService.request<User>({
-    method: "POST",
-    endpoint: "/signup",
-  });
-
-const userService = { login, signup };
-
-export default userService;
+export const userService = new UserService(`${process.env.REACT_APP_API_URL}`);

--- a/packages/client-web/src/services/api/index.ts
+++ b/packages/client-web/src/services/api/index.ts
@@ -1,4 +1,0 @@
-import { ApiService } from "@quoll/client-lib";
-
-// TODO handle the potentially undefined env variable better
-export const apiService = new ApiService(`${process.env.REACT_APP_API_URL}`);

--- a/packages/client-web/src/services/session/index.ts
+++ b/packages/client-web/src/services/session/index.ts
@@ -1,0 +1,10 @@
+import { storage as userStorage } from "modules/user/model";
+
+// A hacky solution for now
+export const getAccessToken = async () => {
+  const userId = userStorage.getData()?.id;
+
+  if (!userId) throw new Error("Unauthenticated");
+
+  return userId;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5924,6 +5924,7 @@ __metadata:
     "@quoll/lib": "npm:^0.3.0"
     "@tsconfig/recommended": "npm:^1.0.3"
     "@types/react": "npm:^18.2.45"
+    moment: "npm:^2.30.1"
     react-redux: "npm:^7.2.1"
     redux: "npm:^4.0.5"
     redux-devtools-extension: "npm:^2.13.9"
@@ -24899,6 +24900,13 @@ __metadata:
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 844c6f3ce42862ac9467c8ca4f5e48a00750078682cc5bda1bc0e50cc7ca88e2115a0f932d65a06e4a90e26cb78892be9b3ca3dd6546ca2c4d994cebb787fc2b
+  languageName: node
+  linkType: hard
+
+"moment@npm:^2.30.1":
+  version: 2.30.1
+  resolution: "moment@npm:2.30.1"
+  checksum: 865e4279418c6de666fca7786607705fd0189d8a7b7624e2e56be99290ac846f90878a6f602e34b4e0455c549b85385b1baf9966845962b313699e7cb847543a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Currently all clients implement their own service
* But it's the same implementation so can be abstracted
* It requires a different "auth" implementation, i.e. create a `getAccessToken` that each service needs to receive from the caller