### PR TITLE
fix: revert subpath exports and tsconfig

### DIFF
--- a/packages/client-lib/package.json
+++ b/packages/client-lib/package.json
@@ -5,20 +5,8 @@
   "repository": "https://github.com/mzogheib/quoll",
   "author": "mzogheib",
   "license": "MIT",
-  "exports": {
-    "./modules": {
-      "import": "./dist/modules/index.js",
-      "types": "./dist/modules/index.d.ts"
-    },
-    "./storage": {
-      "import": "./dist/storage/index.js",
-      "types": "./dist/storage/index.d.ts"
-    },
-    "./store": {
-      "import": "./dist/store/index.js",
-      "types": "./dist/store/index.d.ts"
-    }
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "start": "tsc --watch",
     "clean-build": "rm -rf dist",

--- a/packages/client-mobile/src/modules/date/model/index.ts
+++ b/packages/client-mobile/src/modules/date/model/index.ts
@@ -1,8 +1,5 @@
 import { makeISO8601Date } from "@quoll/lib";
-import {
-  DateState,
-  useDateModel as _useDateModel,
-} from "@quoll/client-lib/modules";
+import { DateState, useDateModel as _useDateModel } from "@quoll/client-lib";
 
 import { makeStore } from "@utils/store";
 

--- a/packages/client-mobile/src/modules/timeline/model/index.ts
+++ b/packages/client-mobile/src/modules/timeline/model/index.ts
@@ -1,7 +1,7 @@
 import {
   TimelineState,
   useTimelineModel as _useTimelineMode,
-} from "@quoll/client-lib/modules";
+} from "@quoll/client-lib";
 
 import { makeStore } from "@utils/store";
 import timelineService from "../service";

--- a/packages/client-mobile/src/modules/timeline/service/index.ts
+++ b/packages/client-mobile/src/modules/timeline/service/index.ts
@@ -1,4 +1,4 @@
-import { TimelineService } from "@quoll/client-lib/modules";
+import { TimelineService } from "@quoll/client-lib";
 import { getAccessToken } from "@utils/session";
 import { API_URL } from "@env";
 

--- a/packages/client-mobile/src/modules/timeline/views/TimelineEntry/index.tsx
+++ b/packages/client-mobile/src/modules/timeline/views/TimelineEntry/index.tsx
@@ -1,5 +1,5 @@
 import FeedLogo from "@components/FeedLogo";
-import { getTimelineEntryImage } from "@quoll/client-lib/modules";
+import { getTimelineEntryImage } from "@quoll/client-lib";
 import {
   TimelineEntry as ITimelineEntry,
   makeDateFromUnixTimestamp,

--- a/packages/client-mobile/src/modules/user/model/index.ts
+++ b/packages/client-mobile/src/modules/user/model/index.ts
@@ -1,7 +1,4 @@
-import {
-  UserState,
-  useUserModel as _useUserModel,
-} from "@quoll/client-lib/modules";
+import { UserState, useUserModel as _useUserModel } from "@quoll/client-lib";
 
 import { makeStorage } from "@utils/storage";
 import { makeStore } from "@utils/store";

--- a/packages/client-mobile/src/modules/user/service/index.ts
+++ b/packages/client-mobile/src/modules/user/service/index.ts
@@ -1,4 +1,4 @@
-import { UserService } from "@quoll/client-lib/modules";
+import { UserService } from "@quoll/client-lib";
 import { API_URL } from "@env";
 
 export const userService = new UserService(API_URL);

--- a/packages/client-mobile/src/utils/storage/index.ts
+++ b/packages/client-mobile/src/utils/storage/index.ts
@@ -1,4 +1,4 @@
-import { Storage } from "@quoll/client-lib/storage";
+import { Storage } from "@quoll/client-lib";
 import { MMKVLoader } from "react-native-mmkv-storage";
 
 const MMKV = new MMKVLoader().initialize();

--- a/packages/client-mobile/src/utils/store/index.ts
+++ b/packages/client-mobile/src/utils/store/index.ts
@@ -1,4 +1,4 @@
-import { Store } from "@quoll/client-lib/store";
+import { Store } from "@quoll/client-lib";
 import { create } from "zustand";
 
 /**

--- a/packages/client-web/package.json
+++ b/packages/client-web/package.json
@@ -42,7 +42,6 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
-    "@tsconfig/create-react-app": "^2.0.5",
     "@types/google.maps": "^3.50.4",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.11.48",

--- a/packages/client-web/src/components/FeedSettings/index.tsx
+++ b/packages/client-web/src/components/FeedSettings/index.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import { ButtonPlain, HorizontalLoader } from "@quoll/ui-components";
 import { FeedName } from "@quoll/lib";
-import { FeedState } from "@quoll/client-lib/modules";
+import { FeedState } from "@quoll/client-lib";
 
 import FeedLogo from "components/FeedLogo";
 

--- a/packages/client-web/src/modules/auth-user/model/index.ts
+++ b/packages/client-web/src/modules/auth-user/model/index.ts
@@ -1,8 +1,8 @@
 import {
   AuthUserState,
   useAuthUserModel as _useAuthUserModel,
-} from "@quoll/client-lib/modules";
-import { makeReduxStoreSlice } from "@quoll/client-lib/store";
+  makeReduxStoreSlice,
+} from "@quoll/client-lib";
 
 import { useAuthUserService } from "../service";
 import { RootState } from "store";

--- a/packages/client-web/src/modules/auth-user/service/index.ts
+++ b/packages/client-web/src/modules/auth-user/service/index.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { AuthUserService } from "@quoll/client-lib/modules";
+import { AuthUserService } from "@quoll/client-lib";
 
 export const useAuthUserService = (getAccessToken: () => Promise<string>) => {
   const service = useMemo(() => {

--- a/packages/client-web/src/modules/date/model/index.ts
+++ b/packages/client-web/src/modules/date/model/index.ts
@@ -1,8 +1,8 @@
 import {
   DateState,
+  makeReduxStoreSlice,
   useDateModel as _useDateModel,
-} from "@quoll/client-lib/modules";
-import { makeReduxStoreSlice } from "@quoll/client-lib/store";
+} from "@quoll/client-lib";
 import { makeISO8601Date } from "@quoll/lib";
 
 import { RootState } from "store";

--- a/packages/client-web/src/modules/feeds/model/index.ts
+++ b/packages/client-web/src/modules/feeds/model/index.ts
@@ -1,8 +1,8 @@
 import {
   FeedsState,
   useFeedsModel as _useFeedsModel,
-} from "@quoll/client-lib/modules";
-import { makeReduxStoreSlice } from "@quoll/client-lib/store";
+  makeReduxStoreSlice,
+} from "@quoll/client-lib";
 import { FeedName } from "@quoll/lib";
 
 import feedsService from "../service";

--- a/packages/client-web/src/modules/feeds/service/index.ts
+++ b/packages/client-web/src/modules/feeds/service/index.ts
@@ -1,4 +1,4 @@
-import { FeedsService } from "@quoll/client-lib/modules";
+import { FeedsService } from "@quoll/client-lib";
 
 import { getAccessToken } from "services/session";
 

--- a/packages/client-web/src/modules/timeline/model/index.ts
+++ b/packages/client-web/src/modules/timeline/model/index.ts
@@ -1,8 +1,8 @@
 import {
   TimelineState,
+  makeReduxStoreSlice,
   useTimelineModel as _useTimelineMode,
-} from "@quoll/client-lib/modules";
-import { makeReduxStoreSlice } from "@quoll/client-lib/store";
+} from "@quoll/client-lib";
 
 import timelineService from "../service";
 import { RootState } from "store";

--- a/packages/client-web/src/modules/timeline/service/index.ts
+++ b/packages/client-web/src/modules/timeline/service/index.ts
@@ -1,4 +1,4 @@
-import { TimelineService } from "@quoll/client-lib/modules";
+import { TimelineService } from "@quoll/client-lib";
 
 import { getAccessToken } from "services/session";
 

--- a/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
+++ b/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
@@ -4,7 +4,7 @@ import {
   makeDateFromUnixTimestamp,
   makeTimeString,
 } from "@quoll/lib";
-import { getTimelineEntryImage } from "@quoll/client-lib/modules";
+import { getTimelineEntryImage } from "@quoll/client-lib";
 
 import FeedLogo from "components/FeedLogo";
 

--- a/packages/client-web/src/modules/user/model/index.ts
+++ b/packages/client-web/src/modules/user/model/index.ts
@@ -1,8 +1,8 @@
 import {
   UserState,
   useUserModel as _useUserModel,
-} from "@quoll/client-lib/modules";
-import { makeReduxStoreSlice } from "@quoll/client-lib/store";
+  makeReduxStoreSlice,
+} from "@quoll/client-lib";
 
 import { makeStorage } from "services/storage";
 import { userService } from "../service";

--- a/packages/client-web/src/modules/user/service/index.ts
+++ b/packages/client-web/src/modules/user/service/index.ts
@@ -1,3 +1,3 @@
-import { UserService } from "@quoll/client-lib/modules";
+import { UserService } from "@quoll/client-lib";
 
 export const userService = new UserService(`${process.env.REACT_APP_API_URL}`);

--- a/packages/client-web/src/services/storage/index.ts
+++ b/packages/client-web/src/services/storage/index.ts
@@ -1,4 +1,4 @@
-import { Storage } from "@quoll/client-lib/storage";
+import { Storage } from "@quoll/client-lib";
 
 const prefix = "quoll";
 

--- a/packages/client-web/src/store/index.ts
+++ b/packages/client-web/src/store/index.ts
@@ -4,8 +4,8 @@ import {
   FeedsState,
   TimelineState,
   UserState,
-} from "@quoll/client-lib/modules";
-import { makeGlobalReduxStore } from "@quoll/client-lib/store";
+  makeGlobalReduxStore,
+} from "@quoll/client-lib";
 
 import { authUserStore } from "modules/auth-user/model";
 import { userStore } from "modules/user/model";

--- a/packages/client-web/tsconfig.json
+++ b/packages/client-web/tsconfig.json
@@ -1,6 +1,20 @@
 {
-  "extends": "@tsconfig/create-react-app/tsconfig.json",
   "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
     "baseUrl": "./src"
   },
   "include": ["src"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7225,7 +7225,6 @@ __metadata:
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.3.0"
     "@testing-library/user-event": "npm:^13.5.0"
-    "@tsconfig/create-react-app": "npm:^2.0.5"
     "@types/google.maps": "npm:^3.50.4"
     "@types/jest": "npm:^27.5.2"
     "@types/node": "npm:^16.11.48"
@@ -10073,13 +10072,6 @@ __metadata:
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
   checksum: 44907308549ce775a41c38a815f747009ac45929a45d642b836aa6b0a536e4978d30b8d7d680bbd116e9dd73b7dbe2ef0d1369dcfc2d09e83ba381e485ecbe12
-  languageName: node
-  linkType: hard
-
-"@tsconfig/create-react-app@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@tsconfig/create-react-app@npm:2.0.5"
-  checksum: 4bc2b66b758c0d1c4d5f19afef07d3bcf989c40c1d996f19add7471ace5fb31d59bf0fa604dcccc32b0a79700824111d33114c104cccac5e8d0e9878da9d74b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* The subpath exports in `client-lib` caused module errors in `client-mobile`
<img width="621" alt="image" src="https://github.com/user-attachments/assets/b93de517-dbcf-4b05-bc8b-43936c99c06b">

* Attempts to fix that then caused other errors in `client-web`
* Hence rolling back to last stable setup

