### PR TITLE
feat: add an authenticated `/user/me` endpoint to get a user

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,6 +9,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.19.2",
+    "express-oauth2-jwt-bearer": "^1.6.0",
     "moment": "^2.29.4",
     "mongoose": "^6.12.3",
     "uuid": "^8.3.2"

--- a/packages/api/src/controllers/user.controller.ts
+++ b/packages/api/src/controllers/user.controller.ts
@@ -30,5 +30,6 @@ export const getUser = async (auth0Id: string): Promise<User | null> => {
 
 export const createUser = async (auth0Id: string): Promise<User> => {
   const user = await UserModel.create({ auth0Id, feeds: DefaultFeeds });
+
   return sanitizeUser(user);
 };

--- a/packages/api/src/controllers/user.controller.ts
+++ b/packages/api/src/controllers/user.controller.ts
@@ -1,6 +1,11 @@
 import { User } from "@quoll/lib";
 import { UserDoc, UserModel } from "../models/user.model";
 
+const DefaultFeeds = [
+  { name: "strava", auth: null },
+  { name: "toshl", auth: null },
+];
+
 const sanitizeUser = (user: UserDoc): User => {
   const feeds = user.feeds.map((feed) => {
     return {
@@ -20,5 +25,10 @@ export const getUser = async (auth0Id: string): Promise<User | null> => {
 
   if (user === null) return null;
 
+  return sanitizeUser(user);
+};
+
+export const createUser = async (auth0Id: string): Promise<User> => {
+  const user = await UserModel.create({ auth0Id, feeds: DefaultFeeds });
   return sanitizeUser(user);
 };

--- a/packages/api/src/controllers/user.controller.ts
+++ b/packages/api/src/controllers/user.controller.ts
@@ -1,0 +1,24 @@
+import { User } from "@quoll/lib";
+import { UserDoc, UserModel } from "../models/user.model";
+
+const sanitizeUser = (user: UserDoc): User => {
+  const feeds = user.feeds.map((feed) => {
+    return {
+      name: feed.name,
+      isConnected: feed.auth !== null,
+    };
+  });
+
+  return {
+    _id: user._id.toString(),
+    feeds,
+  };
+};
+
+export const getUser = async (auth0Id: string): Promise<User | null> => {
+  const user = await UserModel.findOne({ auth0Id });
+
+  if (user === null) return null;
+
+  return sanitizeUser(user);
+};

--- a/packages/api/src/controllers/users.controller.ts
+++ b/packages/api/src/controllers/users.controller.ts
@@ -21,7 +21,10 @@ function sanitizeUser(user: UserDoc): User {
 }
 
 export const createUser = async () => {
-  const user = await UserModel.create({ feeds: DefaultFeeds });
+  const user = await UserModel.create({
+    auth0Id: "", // Not relevant here so we can leave it empty
+    feeds: DefaultFeeds,
+  });
   return sanitizeUser(user);
 };
 

--- a/packages/api/src/controllers/users.controller.ts
+++ b/packages/api/src/controllers/users.controller.ts
@@ -21,8 +21,11 @@ function sanitizeUser(user: UserDoc): User {
 }
 
 export const createUser = async () => {
+  //  Not relevant here so we can make it up
+  const auth0Id = Math.random().toString(36).substring(2, 18);
+
   const user = await UserModel.create({
-    auth0Id: "", // Not relevant here so we can leave it empty
+    auth0Id,
     feeds: DefaultFeeds,
   });
   return sanitizeUser(user);

--- a/packages/api/src/models/user.model.ts
+++ b/packages/api/src/models/user.model.ts
@@ -14,6 +14,7 @@ type IFeed = {
 
 type IUser = {
   feeds: IFeed[];
+  auth0Id: string;
 };
 
 export type UserDoc = HydratedDocument<IUser>;
@@ -26,6 +27,10 @@ const schema = new Schema<IUser>({
         auth: { type: Object },
       },
     ],
+    required: true,
+  },
+  auth0Id: {
+    type: String,
     required: true,
   },
 });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1,0 +1,15 @@
+import { auth, requiredScopes } from "express-oauth2-jwt-bearer";
+
+// Authorization middleware. When used, the Access Token must
+// exist and be verified against the Auth0 JSON Web Key Set.
+const checkJwt = auth({
+  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.AUTH0_ISSUER_BASE_URL,
+  tokenSigningAlg: "RS256",
+});
+
+const scopes = ["read:all_data"];
+
+const checkScopes = requiredScopes(scopes);
+
+export const authMiddleware = [checkJwt, checkScopes];

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -10,7 +10,7 @@ import {
 import { get } from "./timeline.route";
 import { AuthenticatedRequest } from "./types";
 import { authMiddleware } from "./auth";
-import { getMeRoute } from "./user.route";
+import { createMeRoute, getMeRoute } from "./user.route";
 
 const router = Router();
 
@@ -18,7 +18,11 @@ router.route("/login").post(login);
 
 router.route("/signup").post(signup);
 
-router.route("/user/me").all(authMiddleware).get(getMeRoute);
+router
+  .route("/user/me")
+  .all(authMiddleware)
+  .get(getMeRoute)
+  .post(createMeRoute);
 
 router
   .route("/feed-auth")

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -9,12 +9,16 @@ import {
 } from "./feed-auth.route";
 import { get } from "./timeline.route";
 import { AuthenticatedRequest } from "./types";
+import { authMiddleware } from "./auth";
+import { getMeRoute } from "./user.route";
 
 const router = Router();
 
 router.route("/login").post(login);
 
 router.route("/signup").post(signup);
+
+router.route("/user/me").all(authMiddleware).get(getMeRoute);
 
 router
   .route("/feed-auth")

--- a/packages/api/src/routes/user.route.ts
+++ b/packages/api/src/routes/user.route.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { getUser } from "../controllers/user.controller";
+import { createUser, getUser } from "../controllers/user.controller";
 import { handleError } from "../utils/error";
 
 export const getMeRoute = async (req: Request, res: Response) => {
@@ -17,6 +17,23 @@ export const getMeRoute = async (req: Request, res: Response) => {
       res.status(404).json("User not found");
       return;
     }
+
+    res.status(200).json(user);
+  } catch (error) {
+    handleError(error, res);
+  }
+};
+
+export const createMeRoute = async (req: Request, res: Response) => {
+  const auth0Id = req.auth?.payload.sub;
+
+  if (auth0Id === undefined || auth0Id === "") {
+    res.status(401).json("Unauthenticated");
+    return;
+  }
+
+  try {
+    const user = await createUser(auth0Id);
 
     res.status(200).json(user);
   } catch (error) {

--- a/packages/api/src/routes/user.route.ts
+++ b/packages/api/src/routes/user.route.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from "express";
+import { getUser } from "../controllers/user.controller";
+import { handleError } from "../utils/error";
+
+export const getMeRoute = async (req: Request, res: Response) => {
+  const auth0Id = req.auth?.payload.sub;
+
+  if (auth0Id === undefined || auth0Id === "") {
+    res.status(401).json("Unauthenticated");
+    return;
+  }
+
+  try {
+    const user = await getUser(auth0Id);
+
+    if (user === null) {
+      res.status(404).json("User not found");
+      return;
+    }
+
+    res.status(200).json(user);
+  } catch (error) {
+    handleError(error, res);
+  }
+};

--- a/packages/client-lib/src/modules/auth-user/model/index.ts
+++ b/packages/client-lib/src/modules/auth-user/model/index.ts
@@ -30,8 +30,8 @@ export const useAuthUserModel = (
       return user;
     } catch (error) {
       if (error instanceof Error) {
-        const parseError = JSON.parse(error.message);
-        if (parseError.status === 404) return null;
+        const parsedError = JSON.parse(error.message);
+        if (parsedError.status === 404) return null;
       }
 
       throw error;

--- a/packages/client-lib/src/modules/auth-user/model/index.ts
+++ b/packages/client-lib/src/modules/auth-user/model/index.ts
@@ -9,7 +9,7 @@ export type AuthUserState = {
 };
 
 type AuthUserActions = {
-  getMe: () => Promise<User>;
+  getMe: () => Promise<User | null>;
   reset: () => void;
 };
 
@@ -23,12 +23,21 @@ export const useAuthUserModel = (
   const { user, isLoading } = state;
 
   const getMe = async () => {
-    setProperty("isLoading", true);
-    const user = await service.getMe();
-    setProperty("user", user);
-    setProperty("isLoading", false);
+    try {
+      setProperty("isLoading", true);
+      const user = await service.getMe();
+      setProperty("user", user);
+      return user;
+    } catch (error) {
+      if (error instanceof Error) {
+        const parseError = JSON.parse(error.message);
+        if (parseError.status === 404) return null;
+      }
 
-    return user;
+      throw error;
+    } finally {
+      setProperty("isLoading", false);
+    }
   };
 
   return {

--- a/packages/client-web/src/App/utils.ts
+++ b/packages/client-web/src/App/utils.ts
@@ -37,11 +37,22 @@ export const useBootstrapApp = (onUnauthenticated: () => void) => {
 
     setDidCheckAuth(true);
 
-    if (isAuthenticated) {
-      getMe();
-    } else {
+    if (!isAuthenticated) {
       onUnauthenticated();
+      return;
     }
+
+    const getOrCreateUser = async () => {
+      const me = await getMe();
+
+      if (me === null) {
+        // TODO create user
+        onUnauthenticated();
+        return;
+      }
+    };
+
+    getOrCreateUser();
   }, [
     didCheckAuth,
     getMe,

--- a/packages/client-web/src/AppRoot/AuthProvider.tsx
+++ b/packages/client-web/src/AppRoot/AuthProvider.tsx
@@ -18,6 +18,7 @@ const AuthProvider = ({ children }: Props) => (
     authorizationParams={{
       audience: process.env.REACT_APP_AUTH0_AUDIENCE,
       redirect_uri: window.location.origin,
+      scope: "openid profile read:all_data",
     }}
     // These allow the session to be persisted across page refreshes
     useRefreshTokens={true}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7145,6 +7145,7 @@ __metadata:
     cors: "npm:^2.8.5"
     dotenv: "npm:^16.0.1"
     express: "npm:^4.19.2"
+    express-oauth2-jwt-bearer: "npm:^1.6.0"
     moment: "npm:^2.29.4"
     mongoose: "npm:^6.12.3"
     nodemon: "npm:^3.1.4"
@@ -17902,6 +17903,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-oauth2-jwt-bearer@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "express-oauth2-jwt-bearer@npm:1.6.0"
+  dependencies:
+    jose: "npm:^4.13.1"
+  checksum: e68c9b0ded0d2103d2728e3724a25cafef6baf759f7ef4a185c94b0f2b9a0183f700c72e8581398d3965dce6af205a116c1e96b0f9f29ef1d86f921417409091
+  languageName: node
+  linkType: hard
+
 "express@npm:^4.17.3, express@npm:^4.19.2":
   version: 4.19.2
   resolution: "express@npm:4.19.2"
@@ -22597,6 +22607,13 @@ __metadata:
     "@sideway/formula": "npm:^3.0.1"
     "@sideway/pinpoint": "npm:^2.0.0"
   checksum: c41c86fe772828b88fbdbcaef2e41235ccbb107c22523a377f9a2fd39829f203213f37a352589f49d9a9b38bf1c645846defede8b81d8c1f3123117c1a600010
+  languageName: node
+  linkType: hard
+
+"jose@npm:^4.13.1":
+  version: 4.15.9
+  resolution: "jose@npm:4.15.9"
+  checksum: 4ed4ddf4a029db04bd167f2215f65d7245e4dc5f36d7ac3c0126aab38d66309a9e692f52df88975d99429e357e5fd8bab340ff20baab544d17684dd1d940a0f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Adds new auth0 middleware to check the JWT and scopes
* Adds a `GET /user/me` endpoint to fetch a user
* Adds a `POST /user/me` endpoint to create a new user (not used yet)
* auth user model will handle a 404 as a special case and return `null`. For all other errors it just throws them along
* Legacy sign up uses a fake auth0 id just to satisfy the mongoose model