### PR TITLE
refactor: decouple React concepts from client-lib

### DIFF
--- a/packages/client-lib/src/modules/auth-user/model/index.ts
+++ b/packages/client-lib/src/modules/auth-user/model/index.ts
@@ -16,11 +16,11 @@ type AuthUserActions = {
 
 type AuthUserModel = AuthUserState & AuthUserActions;
 
-export const useAuthUserModel = (
-  useStore: () => Store<AuthUserState>,
+export const makeAuthUserModel = (
+  store: Store<AuthUserState>,
   service: AuthUserService,
 ): AuthUserModel => {
-  const { state, setProperty, reset } = useStore();
+  const { state, setProperty, reset } = store;
   const { user, isLoading } = state;
 
   const getMe = async () => {

--- a/packages/client-lib/src/modules/date/model/index.ts
+++ b/packages/client-lib/src/modules/date/model/index.ts
@@ -23,8 +23,8 @@ type DateActions = {
 
 type DateModel = DateState & DateActions;
 
-export const useDateModel = (useStore: () => Store<DateState>): DateModel => {
-  const { state, setProperty, reset } = useStore();
+export const makeDateModel = (store: Store<DateState>): DateModel => {
+  const { state, setProperty, reset } = store;
 
   const setDate = (newDate: ISO8601Date) => setProperty("date", newDate);
 

--- a/packages/client-lib/src/modules/feeds/model/index.ts
+++ b/packages/client-lib/src/modules/feeds/model/index.ts
@@ -21,11 +21,11 @@ type FeedsModel = {
   reset: () => void;
 };
 
-export const useFeedsModel = (
-  useStore: () => Store<FeedsState>,
+export const makeFeedsModel = (
+  store: Store<FeedsState>,
   feedsService: FeedsService,
 ): FeedsModel => {
-  const { setProperty, state: feeds, reset } = useStore();
+  const { setProperty, state: feeds, reset } = store;
 
   const isOneConnected = Object.values(feeds).some((feed) => feed.isConnected);
 

--- a/packages/client-lib/src/modules/timeline/model/index.ts
+++ b/packages/client-lib/src/modules/timeline/model/index.ts
@@ -29,11 +29,11 @@ type TimelineActions = {
 
 type TimelineModel = TimelineState & TimelineActions;
 
-export const useTimelineModel = (
-  useStore: () => Store<TimelineState>,
+export const makeTimelineModel = (
+  store: Store<TimelineState>,
   timelineService: TimelineService,
 ): TimelineModel => {
-  const { state, setProperty, reset } = useStore();
+  const { state, setProperty, reset } = store;
 
   const fetchTimeline = async (date: ISO8601Date) => {
     setProperty("isFetching", true);

--- a/packages/client-mobile/src/modules/auth-user/model/index.ts
+++ b/packages/client-mobile/src/modules/auth-user/model/index.ts
@@ -1,7 +1,4 @@
-import {
-  AuthUserState,
-  useAuthUserModel as _useAuthUserModel,
-} from "@quoll/client-lib";
+import { AuthUserState, makeAuthUserModel } from "@quoll/client-lib";
 
 import { makeStore } from "@utils/store";
 import { useAuthUserService } from "../service";
@@ -14,7 +11,8 @@ const defaultState: AuthUserState = {
 const useStore = makeStore(defaultState);
 
 export const useAuthUserModel = (getAccessToken: () => Promise<string>) => {
+  const store = useStore();
   const service = useAuthUserService(getAccessToken);
 
-  return _useAuthUserModel(useStore, service);
+  return makeAuthUserModel(store, service);
 };

--- a/packages/client-mobile/src/modules/date/model/index.ts
+++ b/packages/client-mobile/src/modules/date/model/index.ts
@@ -1,5 +1,5 @@
 import { makeISO8601Date } from "@quoll/lib";
-import { DateState, useDateModel as _useDateModel } from "@quoll/client-lib";
+import { DateState, makeDateModel } from "@quoll/client-lib";
 
 import { makeStore } from "@utils/store";
 
@@ -9,4 +9,7 @@ const defaultState: DateState = {
 
 const useStore = makeStore(defaultState);
 
-export const useDateModel = () => _useDateModel(useStore);
+export const useDateModel = () => {
+  const store = useStore();
+  return makeDateModel(store);
+};

--- a/packages/client-mobile/src/modules/feeds/model/index.ts
+++ b/packages/client-mobile/src/modules/feeds/model/index.ts
@@ -1,4 +1,4 @@
-import { FeedsState, useFeedsModel as _useFeedsModel } from "@quoll/client-lib";
+import { FeedsState, makeFeedsModel } from "@quoll/client-lib";
 import { FeedName } from "@quoll/lib";
 
 import { makeStore } from "@utils/store";
@@ -19,6 +19,7 @@ const defaultState: FeedsState = {
 const useStore = makeStore(defaultState);
 
 export const useFeedsModel = (getAccessToken: () => Promise<string>) => {
+  const store = useStore();
   const feedsService = useFeedsService(getAccessToken);
-  return _useFeedsModel(useStore, feedsService);
+  return makeFeedsModel(store, feedsService);
 };

--- a/packages/client-mobile/src/modules/timeline/model/index.ts
+++ b/packages/client-mobile/src/modules/timeline/model/index.ts
@@ -1,7 +1,4 @@
-import {
-  TimelineState,
-  useTimelineModel as _useTimelineMode,
-} from "@quoll/client-lib";
+import { TimelineState, makeTimelineModel } from "@quoll/client-lib";
 
 import { makeStore } from "@utils/store";
 import { useTimelineService } from "../service";
@@ -14,7 +11,8 @@ const defaultState: TimelineState = {
 const useStore = makeStore(defaultState);
 
 export const useTimelineModel = (getAccessToken: () => Promise<string>) => {
+  const store = useStore();
   const service = useTimelineService(getAccessToken);
 
-  return _useTimelineMode(useStore, service);
+  return makeTimelineModel(store, service);
 };

--- a/packages/client-web/src/modules/auth-user/model/index.ts
+++ b/packages/client-web/src/modules/auth-user/model/index.ts
@@ -1,6 +1,6 @@
 import {
   AuthUserState,
-  useAuthUserModel as _useAuthUserModel,
+  makeAuthUserModel,
   makeReduxStoreSlice,
 } from "@quoll/client-lib";
 
@@ -18,7 +18,8 @@ export const authUserStore = makeReduxStoreSlice<AuthUserState, RootState>(
 );
 
 export const useAuthUserModel = (getAccessToken: () => Promise<string>) => {
+  const store = authUserStore.useStore();
   const service = useAuthUserService(getAccessToken);
 
-  return _useAuthUserModel(authUserStore.useStore, service);
+  return makeAuthUserModel(store, service);
 };

--- a/packages/client-web/src/modules/date/model/index.ts
+++ b/packages/client-web/src/modules/date/model/index.ts
@@ -1,7 +1,7 @@
 import {
   DateState,
   makeReduxStoreSlice,
-  useDateModel as _useDateModel,
+  makeDateModel,
 } from "@quoll/client-lib";
 import { makeISO8601Date } from "@quoll/lib";
 
@@ -16,4 +16,7 @@ export const dateStore = makeReduxStoreSlice<DateState, RootState>(
   defaultState,
 );
 
-export const useDateModel = () => _useDateModel(dateStore.useStore);
+export const useDateModel = () => {
+  const store = dateStore.useStore();
+  return makeDateModel(store);
+};

--- a/packages/client-web/src/modules/feeds/model/index.ts
+++ b/packages/client-web/src/modules/feeds/model/index.ts
@@ -1,6 +1,6 @@
 import {
   FeedsState,
-  useFeedsModel as _useFeedsModel,
+  makeFeedsModel,
   makeReduxStoreSlice,
 } from "@quoll/client-lib";
 import { FeedName } from "@quoll/lib";
@@ -26,6 +26,7 @@ export const feedsStore = makeReduxStoreSlice<FeedsState, RootState>(
 );
 
 export const useFeedsModel = (getAccessToken: () => Promise<string>) => {
+  const store = feedsStore.useStore();
   const feedsService = useFeedsService(getAccessToken);
-  return _useFeedsModel(feedsStore.useStore, feedsService);
+  return makeFeedsModel(store, feedsService);
 };

--- a/packages/client-web/src/modules/timeline/model/index.ts
+++ b/packages/client-web/src/modules/timeline/model/index.ts
@@ -1,7 +1,7 @@
 import {
   TimelineState,
   makeReduxStoreSlice,
-  useTimelineModel as _useTimelineMode,
+  makeTimelineModel,
 } from "@quoll/client-lib";
 
 import { useTimelineService } from "../service";
@@ -18,6 +18,8 @@ export const timelineStore = makeReduxStoreSlice<TimelineState, RootState>(
 );
 
 export const useTimelineModel = (getAccessToken: () => Promise<string>) => {
-  const timelineService = useTimelineService(getAccessToken);
-  return _useTimelineMode(timelineStore.useStore, timelineService);
+  const store = timelineStore.useStore();
+  const service = useTimelineService(getAccessToken);
+
+  return makeTimelineModel(store, service);
 };


### PR DESCRIPTION
* Currently the `client-lib` defines models as hooks
* This is unnecessarily coupled to React
* It's easy to turn the models into plain TypeScript functions that can work in any client side library or framework