### PR TITLE
refactor: add `exports` to packages

### DIFF
--- a/packages/api/src/controllers/user.controller.ts
+++ b/packages/api/src/controllers/user.controller.ts
@@ -1,4 +1,4 @@
-import { User } from "@quoll/lib";
+import { User } from "@quoll/lib/modules";
 import { UserDoc, UserModel } from "../models/user.model";
 
 const DefaultFeeds = [

--- a/packages/api/src/controllers/users.controller.ts
+++ b/packages/api/src/controllers/users.controller.ts
@@ -1,4 +1,4 @@
-import { FeedName, User } from "@quoll/lib";
+import { FeedName, User } from "@quoll/lib/modules";
 import { IAuth, UserDoc, UserModel } from "../models/user.model";
 
 const DefaultFeeds = [

--- a/packages/api/src/feeds/index.ts
+++ b/packages/api/src/feeds/index.ts
@@ -1,7 +1,7 @@
 import {
   stravaSummaryActivitiesAdapter,
   toshlEntriesAdapter,
-} from "@quoll/lib";
+} from "@quoll/lib/modules";
 
 import { service as stravaService } from "./strava/service";
 import { service as toshlService } from "./toshl/service";

--- a/packages/api/src/feeds/strava/api.ts
+++ b/packages/api/src/feeds/strava/api.ts
@@ -1,4 +1,4 @@
-import { HttpService } from "@quoll/lib";
+import { HttpService } from "@quoll/lib/services";
 
 type Activity = {
   id: number;

--- a/packages/api/src/feeds/strava/oauth-api.ts
+++ b/packages/api/src/feeds/strava/oauth-api.ts
@@ -1,4 +1,4 @@
-import { HttpService } from "@quoll/lib";
+import { HttpService } from "@quoll/lib/services";
 
 if (!process.env.CLIENT_OAUTH_URL) {
   throw new Error("Client OAuth URL not found");

--- a/packages/api/src/feeds/toshl/api.ts
+++ b/packages/api/src/feeds/toshl/api.ts
@@ -1,4 +1,4 @@
-import { HttpService } from "@quoll/lib";
+import { HttpService } from "@quoll/lib/services";
 
 type Entry = {
   id: string;

--- a/packages/api/src/feeds/toshl/oauth-api.ts
+++ b/packages/api/src/feeds/toshl/oauth-api.ts
@@ -1,4 +1,4 @@
-import { HttpService } from "@quoll/lib";
+import { HttpService } from "@quoll/lib/services";
 
 if (!process.env.CLIENT_OAUTH_URL) {
   throw new Error("Client OAuth URL not found");

--- a/packages/api/src/models/user.model.ts
+++ b/packages/api/src/models/user.model.ts
@@ -1,4 +1,4 @@
-import { FeedName } from "@quoll/lib";
+import { FeedName } from "@quoll/lib/modules";
 import { HydratedDocument, Schema, model } from "mongoose";
 
 export type IAuth = {

--- a/packages/api/src/routes/feed-auth.route.ts
+++ b/packages/api/src/routes/feed-auth.route.ts
@@ -5,7 +5,7 @@ import { feedServices, isSupportedFeed } from "../feeds";
 import { setFeedAuth, get, getFeedAuth } from "../controllers/users.controller";
 import { RequestWithUserId } from "./types";
 import { handleError } from "../utils/error";
-import { FeedConnectionConfig } from "@quoll/lib";
+import { FeedConnectionConfig } from "@quoll/lib/modules";
 
 export const connect = (req: RequestWithUserId, res: Response) => {
   const { feed } = req.query;

--- a/packages/client-lib/package.json
+++ b/packages/client-lib/package.json
@@ -5,8 +5,23 @@
   "repository": "https://github.com/mzogheib/quoll",
   "author": "mzogheib",
   "license": "MIT",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    "./modules": {
+      "types": "./dist/modules/index.d.ts",
+      "import": "./dist/modules/index.js",
+      "require": "./dist/modules/index.js"
+    },
+    "./storage": {
+      "types": "./dist/storage/index.d.ts",
+      "import": "./dist/storage/index.js",
+      "require": "./dist/storage/index.js"
+    },
+    "./store": {
+      "types": "./dist/store/index.d.ts",
+      "import": "./dist/store/index.js",
+      "require": "./dist/store/index.js"
+    }
+  },
   "scripts": {
     "start": "quoll-build-deps && tsc --watch",
     "clean-build": "rm -rf dist",

--- a/packages/client-lib/src/modules/auth-user/model/index.ts
+++ b/packages/client-lib/src/modules/auth-user/model/index.ts
@@ -1,4 +1,4 @@
-import { User } from "@quoll/lib";
+import { User } from "@quoll/lib/modules";
 
 import { Store } from "../../../store/types";
 import { UserService } from "../service";

--- a/packages/client-lib/src/modules/auth-user/service/index.ts
+++ b/packages/client-lib/src/modules/auth-user/service/index.ts
@@ -1,4 +1,5 @@
-import { AuthenticatedHttpService, User } from "@quoll/lib";
+import { User } from "@quoll/lib/modules";
+import { AuthenticatedHttpService } from "@quoll/lib/services";
 
 export class UserService extends AuthenticatedHttpService {
   async getMe() {

--- a/packages/client-lib/src/modules/date/model/index.ts
+++ b/packages/client-lib/src/modules/date/model/index.ts
@@ -1,4 +1,4 @@
-import { ISO8601Date } from "@quoll/lib";
+import { ISO8601Date } from "@quoll/lib/modules";
 
 import { Store } from "../../../store/types";
 

--- a/packages/client-lib/src/modules/feeds/model/index.ts
+++ b/packages/client-lib/src/modules/feeds/model/index.ts
@@ -1,4 +1,4 @@
-import { FeedConnectionConfig, FeedName } from "@quoll/lib";
+import { FeedConnectionConfig, FeedName } from "@quoll/lib/modules";
 
 import { Store } from "../../../store";
 import { FeedsService } from "../service";

--- a/packages/client-lib/src/modules/feeds/service/index.ts
+++ b/packages/client-lib/src/modules/feeds/service/index.ts
@@ -1,8 +1,5 @@
-import {
-  AuthenticatedHttpService,
-  FeedConnectionConfig,
-  FeedName,
-} from "@quoll/lib";
+import { FeedConnectionConfig, FeedName } from "@quoll/lib/modules";
+import { AuthenticatedHttpService } from "@quoll/lib/services";
 
 type AuthenticatePayload = {
   code: string;

--- a/packages/client-lib/src/modules/timeline/model/index.ts
+++ b/packages/client-lib/src/modules/timeline/model/index.ts
@@ -1,4 +1,4 @@
-import { ISO8601Date, TimelineEntry } from "@quoll/lib";
+import { ISO8601Date, TimelineEntry } from "@quoll/lib/modules";
 
 import { Store } from "../../../store/types";
 import { TimelineService } from "../service";

--- a/packages/client-lib/src/modules/timeline/service/index.ts
+++ b/packages/client-lib/src/modules/timeline/service/index.ts
@@ -1,11 +1,11 @@
 import {
-  AuthenticatedHttpService,
   ISO8601Date,
   TimelineEntry,
   TimelineEntryType,
   getEndOfDay,
   getStartOfDay,
-} from "@quoll/lib";
+} from "@quoll/lib/modules";
+import { AuthenticatedHttpService } from "@quoll/lib/services";
 
 type EntryConfig = {
   label: string;

--- a/packages/client-mobile/metro.config.js
+++ b/packages/client-mobile/metro.config.js
@@ -11,7 +11,9 @@ const config = {
   resolver: {
     // Helps with importing local packages
     nodeModulesPaths: [path.resolve(__dirname, "./node_modules")],
+    // To support `exports` field in dependencies
     unstable_enablePackageExports: true,
+    // To support `exports` field's `require` in dependencies
     unstable_conditionNames: ["require"],
   },
   watchFolders: [

--- a/packages/client-mobile/metro.config.js
+++ b/packages/client-mobile/metro.config.js
@@ -12,7 +12,7 @@ const config = {
     // Helps with importing local packages
     nodeModulesPaths: [path.resolve(__dirname, "./node_modules")],
     unstable_enablePackageExports: true,
-    unstable_conditionNames: ["browser", "require", "react-native"],
+    unstable_conditionNames: ["require"],
   },
   watchFolders: [
     // Helps with importing local packages

--- a/packages/client-mobile/metro.config.js
+++ b/packages/client-mobile/metro.config.js
@@ -11,6 +11,8 @@ const config = {
   resolver: {
     // Helps with importing local packages
     nodeModulesPaths: [path.resolve(__dirname, "./node_modules")],
+    unstable_enablePackageExports: true,
+    unstable_conditionNames: ["browser", "require", "react-native"],
   },
   watchFolders: [
     // Helps with importing local packages

--- a/packages/client-mobile/src/components/FeedLogo/index.tsx
+++ b/packages/client-mobile/src/components/FeedLogo/index.tsx
@@ -1,5 +1,5 @@
 import Icon from "react-native-vector-icons/MaterialIcons";
-import { FeedName } from "@quoll/lib";
+import { FeedName } from "@quoll/lib/modules";
 import { colorPalette } from "@quoll/ui-primitives";
 
 const iconMap = {

--- a/packages/client-mobile/src/modules/auth-user/model/index.ts
+++ b/packages/client-mobile/src/modules/auth-user/model/index.ts
@@ -1,4 +1,4 @@
-import { UserState, makeUserModel } from "@quoll/client-lib";
+import { UserState, makeUserModel } from "@quoll/client-lib/modules";
 
 import { makeStore } from "@utils/store";
 import { useUserService } from "../service";

--- a/packages/client-mobile/src/modules/auth-user/service/index.ts
+++ b/packages/client-mobile/src/modules/auth-user/service/index.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { UserService } from "@quoll/client-lib";
+import { UserService } from "@quoll/client-lib/modules";
 import { getApiBaseUrl } from "@utils/api";
 
 export const useUserService = (getAccessToken: () => Promise<string>) => {

--- a/packages/client-mobile/src/modules/auth/model/index.ts
+++ b/packages/client-mobile/src/modules/auth/model/index.ts
@@ -1,6 +1,6 @@
 import { AUTH0_AUDIENCE } from "@env";
 import { useAuth0 } from "react-native-auth0";
-import { AuthModel } from "@quoll/client-lib";
+import { AuthModel } from "@quoll/client-lib/modules";
 
 const makeAuthParams = () => {
   if (!AUTH0_AUDIENCE) throw new Error("Missing Auth0 configuration");

--- a/packages/client-mobile/src/modules/auth/view-model/index.ts
+++ b/packages/client-mobile/src/modules/auth/view-model/index.ts
@@ -1,4 +1,4 @@
-import { AuthModel } from "@quoll/client-lib";
+import { AuthModel } from "@quoll/client-lib/modules";
 import { useAuthModel } from "../model";
 import { useDateModel } from "@modules/date/model";
 import { useUserModel } from "@modules/auth-user/model";

--- a/packages/client-mobile/src/modules/date/model/index.ts
+++ b/packages/client-mobile/src/modules/date/model/index.ts
@@ -1,4 +1,4 @@
-import { makeISO8601Date } from "@quoll/lib";
+import { makeISO8601Date } from "@quoll/lib/modules";
 import { DateState, makeDateModel } from "@quoll/client-lib";
 
 import { makeStore } from "@utils/store";

--- a/packages/client-mobile/src/modules/date/model/index.ts
+++ b/packages/client-mobile/src/modules/date/model/index.ts
@@ -1,5 +1,5 @@
 import { makeISO8601Date } from "@quoll/lib/modules";
-import { DateState, makeDateModel } from "@quoll/client-lib";
+import { DateState, makeDateModel } from "@quoll/client-lib/modules";
 
 import { makeStore } from "@utils/store";
 

--- a/packages/client-mobile/src/modules/date/ui/DateBar/index.tsx
+++ b/packages/client-mobile/src/modules/date/ui/DateBar/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { View, TouchableHighlight, Text } from "react-native";
 import DatePicker from "react-native-date-picker";
-import { getEndOfDay, getOffsetDate } from "@quoll/lib";
+import { getEndOfDay, getOffsetDate } from "@quoll/lib/modules";
 
 import styles from "./styles";
 

--- a/packages/client-mobile/src/modules/feeds/model/index.ts
+++ b/packages/client-mobile/src/modules/feeds/model/index.ts
@@ -1,5 +1,5 @@
 import { FeedsState, makeFeedsModel } from "@quoll/client-lib";
-import { FeedName } from "@quoll/lib";
+import { FeedName } from "@quoll/lib/modules";
 
 import { makeStore } from "@utils/store";
 import { useFeedsService } from "../service";

--- a/packages/client-mobile/src/modules/feeds/model/index.ts
+++ b/packages/client-mobile/src/modules/feeds/model/index.ts
@@ -1,4 +1,4 @@
-import { FeedsState, makeFeedsModel } from "@quoll/client-lib";
+import { FeedsState, makeFeedsModel } from "@quoll/client-lib/modules";
 import { FeedName } from "@quoll/lib/modules";
 
 import { makeStore } from "@utils/store";

--- a/packages/client-mobile/src/modules/feeds/service/index.ts
+++ b/packages/client-mobile/src/modules/feeds/service/index.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { FeedsService } from "@quoll/client-lib";
+import { FeedsService } from "@quoll/client-lib/modules";
 import { getApiBaseUrl } from "@utils/api";
 
 export const useFeedsService = (getAccessToken: () => Promise<string>) => {

--- a/packages/client-mobile/src/modules/media/model/index.ts
+++ b/packages/client-mobile/src/modules/media/model/index.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from "react";
-import { ISO8601Date } from "@quoll/lib";
+import { ISO8601Date } from "@quoll/lib/modules";
 
 import { makeStore } from "@utils/store";
 import { makeStorage } from "@utils/storage";

--- a/packages/client-mobile/src/modules/media/model/utils.ts
+++ b/packages/client-mobile/src/modules/media/model/utils.ts
@@ -3,7 +3,7 @@ import {
   getEndOfDay,
   getStartOfDay,
   ISO8601Date,
-} from "@quoll/lib";
+} from "@quoll/lib/modules";
 import { DateFilter } from "../types";
 
 /**

--- a/packages/client-mobile/src/modules/media/view-model/index.ts
+++ b/packages/client-mobile/src/modules/media/view-model/index.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { Alert } from "react-native";
-import { ISO8601Date } from "@quoll/lib";
+import { ISO8601Date } from "@quoll/lib/modules";
 
 import { promptAllowAccess } from "@components/Alert";
 import { useMediaModel } from "../model";

--- a/packages/client-mobile/src/modules/timeline/model/index.ts
+++ b/packages/client-mobile/src/modules/timeline/model/index.ts
@@ -1,4 +1,4 @@
-import { TimelineState, makeTimelineModel } from "@quoll/client-lib";
+import { TimelineState, makeTimelineModel } from "@quoll/client-lib/modules";
 
 import { makeStore } from "@utils/store";
 import { useTimelineService } from "../service";

--- a/packages/client-mobile/src/modules/timeline/service/index.ts
+++ b/packages/client-mobile/src/modules/timeline/service/index.ts
@@ -1,4 +1,4 @@
-import { TimelineService } from "@quoll/client-lib";
+import { TimelineService } from "@quoll/client-lib/modules";
 import { getApiBaseUrl } from "@utils/api";
 import { useMemo } from "react";
 

--- a/packages/client-mobile/src/modules/timeline/view-model/feed-adapters/media.ts
+++ b/packages/client-mobile/src/modules/timeline/view-model/feed-adapters/media.ts
@@ -1,5 +1,5 @@
 import { MediaItem } from "@modules/media/types";
-import { TimelineEntry, TimelineEntryType } from "@quoll/lib";
+import { TimelineEntry, TimelineEntryType } from "@quoll/lib/modules";
 
 const getType = (mediaItem: MediaItem): TimelineEntryType => {
   switch (mediaItem.subTypes) {

--- a/packages/client-mobile/src/modules/timeline/view-model/index.ts
+++ b/packages/client-mobile/src/modules/timeline/view-model/index.ts
@@ -1,4 +1,4 @@
-import { ISO8601Date, TimelineEntry } from "@quoll/lib";
+import { ISO8601Date, TimelineEntry } from "@quoll/lib/modules";
 import { useMediaModel } from "@modules/media/model";
 import { useAuthModel } from "@modules/auth/model";
 import { useTimelineModel } from "../model";

--- a/packages/client-mobile/src/modules/timeline/views/Timeline/index.tsx
+++ b/packages/client-mobile/src/modules/timeline/views/Timeline/index.tsx
@@ -1,5 +1,5 @@
 import { View } from "react-native";
-import { TimelineEntry as ITimelineEntry } from "@quoll/lib";
+import { TimelineEntry as ITimelineEntry } from "@quoll/lib/modules";
 
 import TimelineEntry from "../TimelineEntry";
 

--- a/packages/client-mobile/src/modules/timeline/views/TimelineEntry/index.tsx
+++ b/packages/client-mobile/src/modules/timeline/views/TimelineEntry/index.tsx
@@ -4,7 +4,7 @@ import {
   TimelineEntry as ITimelineEntry,
   makeDateFromUnixTimestamp,
   makeTimeString,
-} from "@quoll/lib";
+} from "@quoll/lib/modules";
 import { TouchableHighlight, Text, View } from "react-native";
 import styles from "./styles";
 

--- a/packages/client-mobile/src/modules/timeline/views/TimelineEntry/index.tsx
+++ b/packages/client-mobile/src/modules/timeline/views/TimelineEntry/index.tsx
@@ -1,5 +1,5 @@
 import FeedLogo from "@components/FeedLogo";
-import { getTimelineEntryImage } from "@quoll/client-lib";
+import { getTimelineEntryImage } from "@quoll/client-lib/modules";
 import {
   TimelineEntry as ITimelineEntry,
   makeDateFromUnixTimestamp,

--- a/packages/client-mobile/src/screens/ScreenStack/Home/controller.ts
+++ b/packages/client-mobile/src/screens/ScreenStack/Home/controller.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { makeISO8601Date } from "@quoll/lib";
+import { makeISO8601Date } from "@quoll/lib/modules";
 
 import { MarkerProps } from "@components/Map/types";
 import { useDateViewModel } from "@modules/date/view-model";

--- a/packages/client-mobile/src/utils/storage/index.ts
+++ b/packages/client-mobile/src/utils/storage/index.ts
@@ -1,4 +1,4 @@
-import { Storage } from "@quoll/client-lib";
+import { Storage } from "@quoll/client-lib/storage";
 import { MMKVLoader } from "react-native-mmkv-storage";
 
 const MMKV = new MMKVLoader().initialize();

--- a/packages/client-mobile/src/utils/store/index.ts
+++ b/packages/client-mobile/src/utils/store/index.ts
@@ -1,4 +1,4 @@
-import { Store } from "@quoll/client-lib";
+import { Store } from "@quoll/client-lib/store";
 import { create } from "zustand";
 
 /**

--- a/packages/client-web/src/components/FeedLogo/index.tsx
+++ b/packages/client-web/src/components/FeedLogo/index.tsx
@@ -1,4 +1,4 @@
-import { FeedName } from "@quoll/lib";
+import { FeedName } from "@quoll/lib/modules";
 
 const logoMap = {
   toshl: {

--- a/packages/client-web/src/components/FeedSettings/index.tsx
+++ b/packages/client-web/src/components/FeedSettings/index.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import { ButtonPlain, HorizontalLoader } from "@quoll/ui-components";
 import { FeedName } from "@quoll/lib/modules";
-import { FeedState } from "@quoll/client-lib";
+import { FeedState } from "@quoll/client-lib/modules";
 
 import FeedLogo from "components/FeedLogo";
 

--- a/packages/client-web/src/components/FeedSettings/index.tsx
+++ b/packages/client-web/src/components/FeedSettings/index.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 import { ButtonPlain, HorizontalLoader } from "@quoll/ui-components";
-import { FeedName } from "@quoll/lib";
+import { FeedName } from "@quoll/lib/modules";
 import { FeedState } from "@quoll/client-lib";
 
 import FeedLogo from "components/FeedLogo";

--- a/packages/client-web/src/modules/auth-user/model/index.ts
+++ b/packages/client-web/src/modules/auth-user/model/index.ts
@@ -1,8 +1,5 @@
-import {
-  UserState,
-  makeUserModel,
-  makeReduxStoreSlice,
-} from "@quoll/client-lib";
+import { UserState, makeUserModel } from "@quoll/client-lib/modules";
+import { makeReduxStoreSlice } from "@quoll/client-lib/store";
 
 import { useUserService } from "../service";
 import { RootState } from "store";

--- a/packages/client-web/src/modules/auth-user/service/index.ts
+++ b/packages/client-web/src/modules/auth-user/service/index.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { UserService } from "@quoll/client-lib";
+import { UserService } from "@quoll/client-lib/modules";
 import { getApiBaseUrl } from "services/api";
 
 export const useUserService = (getAccessToken: () => Promise<string>) => {

--- a/packages/client-web/src/modules/auth/model/index.ts
+++ b/packages/client-web/src/modules/auth/model/index.ts
@@ -1,5 +1,5 @@
 import { useAuth0 } from "@auth0/auth0-react";
-import { AuthModel } from "@quoll/client-lib";
+import { AuthModel } from "@quoll/client-lib/modules";
 
 export const useAuthModel = (): AuthModel => {
   const {

--- a/packages/client-web/src/modules/auth/view-model/index.ts
+++ b/packages/client-web/src/modules/auth/view-model/index.ts
@@ -1,4 +1,4 @@
-import { AuthModel } from "@quoll/client-lib";
+import { AuthModel } from "@quoll/client-lib/modules";
 import { useAuthModel } from "../model";
 import { useTimelineModel } from "modules/timeline/model";
 import { useFeedsModel } from "modules/feeds/model";

--- a/packages/client-web/src/modules/date/model/index.ts
+++ b/packages/client-web/src/modules/date/model/index.ts
@@ -3,7 +3,7 @@ import {
   makeReduxStoreSlice,
   makeDateModel,
 } from "@quoll/client-lib";
-import { makeISO8601Date } from "@quoll/lib";
+import { makeISO8601Date } from "@quoll/lib/modules";
 
 import { RootState } from "store";
 

--- a/packages/client-web/src/modules/date/model/index.ts
+++ b/packages/client-web/src/modules/date/model/index.ts
@@ -1,8 +1,5 @@
-import {
-  DateState,
-  makeReduxStoreSlice,
-  makeDateModel,
-} from "@quoll/client-lib";
+import { DateState, makeDateModel } from "@quoll/client-lib/modules";
+import { makeReduxStoreSlice } from "@quoll/client-lib/store";
 import { makeISO8601Date } from "@quoll/lib/modules";
 
 import { RootState } from "store";

--- a/packages/client-web/src/modules/date/views/DatePicker/index.tsx
+++ b/packages/client-web/src/modules/date/views/DatePicker/index.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import styled, { css } from "styled-components";
 import { Calendar, IconButton } from "@quoll/ui-components";
-import { ISO8601Date, getOffsetDate, makeISO8601Date } from "@quoll/lib";
+import {
+  ISO8601Date,
+  getOffsetDate,
+  makeISO8601Date,
+} from "@quoll/lib/modules";
 
 const Wrapper = styled.div`
   display: flex;

--- a/packages/client-web/src/modules/feeds/model/index.ts
+++ b/packages/client-web/src/modules/feeds/model/index.ts
@@ -3,7 +3,7 @@ import {
   makeFeedsModel,
   makeReduxStoreSlice,
 } from "@quoll/client-lib";
-import { FeedName } from "@quoll/lib";
+import { FeedName } from "@quoll/lib/modules";
 
 import { useFeedsService } from "../service";
 import { RootState } from "store";

--- a/packages/client-web/src/modules/feeds/model/index.ts
+++ b/packages/client-web/src/modules/feeds/model/index.ts
@@ -1,8 +1,5 @@
-import {
-  FeedsState,
-  makeFeedsModel,
-  makeReduxStoreSlice,
-} from "@quoll/client-lib";
+import { FeedsState, makeFeedsModel } from "@quoll/client-lib/modules";
+import { makeReduxStoreSlice } from "@quoll/client-lib/store";
 import { FeedName } from "@quoll/lib/modules";
 
 import { useFeedsService } from "../service";

--- a/packages/client-web/src/modules/feeds/service/index.ts
+++ b/packages/client-web/src/modules/feeds/service/index.ts
@@ -1,4 +1,4 @@
-import { FeedsService } from "@quoll/client-lib";
+import { FeedsService } from "@quoll/client-lib/modules";
 import { useMemo } from "react";
 import { getApiBaseUrl } from "services/api";
 

--- a/packages/client-web/src/modules/timeline/model/index.ts
+++ b/packages/client-web/src/modules/timeline/model/index.ts
@@ -1,11 +1,8 @@
-import {
-  TimelineState,
-  makeReduxStoreSlice,
-  makeTimelineModel,
-} from "@quoll/client-lib";
+import { TimelineState, makeTimelineModel } from "@quoll/client-lib/modules";
 
 import { useTimelineService } from "../service";
 import { RootState } from "store";
+import { makeReduxStoreSlice } from "@quoll/client-lib/store";
 
 const defaultState: TimelineState = {
   isFetching: false,

--- a/packages/client-web/src/modules/timeline/service/index.ts
+++ b/packages/client-web/src/modules/timeline/service/index.ts
@@ -1,4 +1,4 @@
-import { TimelineService } from "@quoll/client-lib";
+import { TimelineService } from "@quoll/client-lib/modules";
 import { useMemo } from "react";
 import { getApiBaseUrl } from "services/api";
 

--- a/packages/client-web/src/modules/timeline/views/Timeline/index.tsx
+++ b/packages/client-web/src/modules/timeline/views/Timeline/index.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { TimelineEntry as ITimelineEntry } from "@quoll/lib";
+import { TimelineEntry as ITimelineEntry } from "@quoll/lib/modules";
 
 import TimelineEntry from "../TimelineEntry";
 

--- a/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
+++ b/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
@@ -3,7 +3,7 @@ import {
   TimelineEntry as ITimelineEntry,
   makeDateFromUnixTimestamp,
   makeTimeString,
-} from "@quoll/lib";
+} from "@quoll/lib/modules";
 import { getTimelineEntryImage } from "@quoll/client-lib";
 
 import FeedLogo from "components/FeedLogo";

--- a/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
+++ b/packages/client-web/src/modules/timeline/views/TimelineEntry/index.tsx
@@ -4,7 +4,7 @@ import {
   makeDateFromUnixTimestamp,
   makeTimeString,
 } from "@quoll/lib/modules";
-import { getTimelineEntryImage } from "@quoll/client-lib";
+import { getTimelineEntryImage } from "@quoll/client-lib/modules";
 
 import FeedLogo from "components/FeedLogo";
 

--- a/packages/client-web/src/routes/Home/index.tsx
+++ b/packages/client-web/src/routes/Home/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import styled, { css } from "styled-components";
 import { HorizontalLoader } from "@quoll/ui-components";
-import { ISO8601Date, isSameDay, makeISO8601Date } from "@quoll/lib";
+import { ISO8601Date, isSameDay, makeISO8601Date } from "@quoll/lib/modules";
 
 import { useTimelineViewModel } from "modules/timeline/view-model";
 import { useDateViewModelModel } from "modules/date/view-model";

--- a/packages/client-web/src/routes/Home/mapUtils.ts
+++ b/packages/client-web/src/routes/Home/mapUtils.ts
@@ -2,7 +2,7 @@ import {
   TimelineEntry,
   makeDateFromUnixTimestamp,
   makeTimeString,
-} from "@quoll/lib";
+} from "@quoll/lib/modules";
 
 import { MarkerConfig, PolylineConfig } from "components/Map/Component";
 import { decodePath } from "components/Map/utils";

--- a/packages/client-web/src/routes/Settings/index.tsx
+++ b/packages/client-web/src/routes/Settings/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import styled from "styled-components";
 import { useHistory, useLocation } from "react-router-dom";
-import { FeedName } from "@quoll/lib";
+import { FeedName } from "@quoll/lib/modules";
 
 import { useFeedsViewModel } from "modules/feeds/view-model";
 import FeedSettings from "components/FeedSettings";

--- a/packages/client-web/src/services/storage/index.ts
+++ b/packages/client-web/src/services/storage/index.ts
@@ -1,4 +1,4 @@
-import { Storage } from "@quoll/client-lib";
+import { Storage } from "@quoll/client-lib/storage";
 
 const prefix = "quoll";
 

--- a/packages/client-web/src/store/index.ts
+++ b/packages/client-web/src/store/index.ts
@@ -3,8 +3,8 @@ import {
   DateState,
   FeedsState,
   TimelineState,
-  makeGlobalReduxStore,
-} from "@quoll/client-lib";
+} from "@quoll/client-lib/modules";
+import { makeGlobalReduxStore } from "@quoll/client-lib/store";
 
 import { userStore } from "modules/auth-user/model";
 import { dateStore } from "modules/date/model";

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -5,8 +5,18 @@
   "repository": "https://github.com/mzogheib/quoll",
   "author": "mzogheib",
   "license": "MIT",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    "./modules": {
+      "types": "./dist/modules/index.d.ts",
+      "import": "./dist/modules/index.js",
+      "require": "./dist/modules/index.js"
+    },
+    "./services": {
+      "types": "./dist/services/index.d.ts",
+      "import": "./dist/services/index.js",
+      "require": "./dist/services/index.js"
+    }
+  },
   "scripts": {
     "start": "quoll-build-deps && tsc --watch",
     "clean-build": "rm -rf dist",


### PR DESCRIPTION
* Current the lower level packages export everything from `main`
* The `exports` property (see [here](https://nodejs.org/docs/latest-v18.x/api/packages.html#package-entry-points)) allows for subpath exports