### PR TITLE
build: fix publish scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "workspaces": [
     "packages/*"
   ],
-  "bin": {
-    "quoll-build-deps": "./scripts/build-deps.js"
-  },
   "scripts": {
     "start": "./scripts/start.sh",
     "release": "./scripts/release.sh",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,10 +15,10 @@
     "uuid": "^8.3.2"
   },
   "scripts": {
-    "start": "quoll-build-deps && nodemon src/server.ts",
+    "start": "node ../../scripts/build-deps.js && nodemon src/server.ts",
     "start-db": "docker-compose -f db/local/compose.yaml up",
     "clean-dist": "rm -rf dist",
-    "build": "tsc",
+    "build": "node ../../scripts/build-deps.js && tsc",
     "serve": "node dist/server.js",
     "type-check": "tsc --noEmit"
   },

--- a/packages/client-lib/package.json
+++ b/packages/client-lib/package.json
@@ -23,11 +23,11 @@
     }
   },
   "scripts": {
-    "start": "quoll-build-deps && tsc --watch",
+    "start": "node ../../scripts/build-deps.js && tsc --watch",
     "clean-build": "rm -rf dist",
-    "build": "yarn clean-build && tsc",
+    "build": "node ../../scripts/build-deps.js && yarn clean-build && tsc",
     "type-check": "tsc --noEmit",
-    "prepare": "yarn build",
+    "prepack": "yarn build",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/client-mobile/package.json
+++ b/packages/client-mobile/package.json
@@ -8,7 +8,7 @@
     "ios": "react-native run-ios",
     "ios-rebuild": "cd ios/ && rm -rf build/ Pods/ && bundle install && bundle exec pod install && cd ..",
     "lint": "eslint .",
-    "start": "quoll-build-deps && react-native start",
+    "start": "node ../../scripts/build-deps.js && react-native start",
     "test": "jest",
     "type-check": "tsc --noEmit"
   },

--- a/packages/client-web/package.json
+++ b/packages/client-web/package.json
@@ -3,7 +3,7 @@
   "version": "0.16.2",
   "private": true,
   "scripts": {
-    "start": "quoll-build-deps && react-scripts start",
+    "start": "node ../../scripts/build-deps.js && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -30,9 +30,9 @@
   "scripts": {
     "start": "tsc --watch",
     "clean-build": "rm -rf dist",
-    "build": "yarn clean-build && tsc",
+    "build": "node ../../scripts/build-deps.js && yarn clean-build && tsc",
     "type-check": "tsc --noEmit",
-    "prepare": "yarn build"
+    "prepack": "yarn build"
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.4",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -15,11 +15,11 @@
     "node": ">=18"
   },
   "scripts": {
-    "start": "quoll-build-deps && tsdx watch",
-    "build": "tsdx build",
+    "start": "node ../../scripts/build-deps.js && tsdx watch",
+    "build": "node ../../scripts/build-deps.js && tsdx build",
     "test": "tsdx test --passWithNoTests",
     "lint": "tsdx lint",
-    "prepare": "yarn build",
+    "prepack": "yarn build",
     "size": "size-limit",
     "analyze": "size-limit --why",
     "storybook": "storybook dev -p 6006",

--- a/packages/ui-primitives/package.json
+++ b/packages/ui-primitives/package.json
@@ -8,9 +8,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "quoll-build-deps && tsc --watch",
-    "prepare": "yarn build",
+    "build": "node ../../scripts/build-deps.js && tsc",
+    "start": "node ../../scripts/build-deps.js && tsc --watch",
+    "prepack": "yarn build",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
* Publish workflow is failing mysteriously
  * https://github.com/mzogheib/quoll/actions/runs/13213027304/job/36888954121
  * <img width="1056" alt="image" src="https://github.com/user-attachments/assets/ac80f738-2d33-4ebc-ae3f-e5021a0fdf30" />
* Most likely because the `prepare` script that I assumed would run _after_ install on CI [isn't supported by Yarn](https://yarnpkg.com/advanced/lifecycle-scripts).
  * ![image](https://github.com/user-attachments/assets/70524a72-ccab-47ef-80a6-7df058d453ab)
* Hence, attempts to build packages just prior to publish is failing because their dependencies are not being built
* As per [here](https://yarnpkg.com/advanced/lifecycle-scripts) `prepack` is supported
* So when publishing a package:
  * `prepack` is run
  * Build the package's deps first
  * Then build the package
  * Then publish it 
* But how has it been working so far? Perhaps from cached installations or builds? No idea...
 
